### PR TITLE
Removed Belgian coal and oil

### DIFF
--- a/web/app/configs/capacities.json
+++ b/web/app/configs/capacities.json
@@ -14,8 +14,8 @@
         "capacity": {
             "biomass": 1078,
             "nuclear": 5919,
-            "oil": 145,
-            "coal": 470,
+            "oil": 0,
+            "coal": 0,
             "hydro": 1425,
             "gas": 5303,
             "wind": 1961,


### PR DESCRIPTION
In march of 2016 the Langerlo coal plant in Belgium was shut down marking the end of coal in Belgium.
Sources: 
https://nl.express.live/2016/03/31/belgie-laat-steenkooltijdperk-zich/
http://www.greenpeace.org/belgium/nl/nieuws/klimaat-energie/blog/belgie-neemt-definitief-afscheid-van-steenkool/blog/56043/

Oil is no longer used either though I can't find any news articles on this though it no longer is in the ENTSOE list:
https://transparency.entsoe.eu/generation/r2/installedCapacityPerProductionUnit/show