### PR TITLE
Capacities update for Ontario, Canada (IESO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Production capacities are centralized in the [capacities.json](https://github.co
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Belgium: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Bulgaria: [wikipedia.org](https://en.wikipedia.org/wiki/Energy_in_Bulgaria)
+- Canada (Ontario): [Gridwatch](http://live.gridwatch.ca/total-capacity.html)
 - Czech Republic: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Denmark
   - Solar: [wikipedia.org](https://en.wikipedia.org/wiki/Solar_power_in_Denmark)

--- a/config/capacities.json
+++ b/config/capacities.json
@@ -10,6 +10,16 @@
             "wind": 2556
         }
     },
+    "CA-ON": {    
+        "capacity": {
+            "biomass": 495,
+            "nuclear": 12978,
+            "gas" : 9943,
+            "hydro": 8451,
+            "wind": 3923,
+            "solar": 280
+        }
+    },
     "BE": {
         "capacity": {
             "biomass": 1078,
@@ -317,7 +327,7 @@
             "biomass": 363,
             "nuclear": 1940,
             "coal": 1008,
-	          "gas" : 1093,
+            "gas" : 1093,
             "oil": 195,
             "hydro": 2533,
             "wind": 3,


### PR DESCRIPTION
Data added is all from http://live.gridwatch.ca/total-capacity.html (last updated December 2016), and I added that link to the readme.md file as well. Couldn't find any better source on IESO's site directly (which I found odd), gridwatch is generally a reputable source, and the numbers appear accurate when compared with some of IESO's data, so I think it's the best source we'll get for now.