### PR TITLE
Update Spain production capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Production capacities are centralized in the [capacities.json](https://github.co
 - Serbia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Slovakia: [SEPS](https://www.sepsas.sk/Dokumenty/RocenkySed/ROCENKA_SED_2015.pdf)
 - Slovenia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
-- Spain: [ree.es](http://www.ree.es/sites/default/files/downloadable/preliminary_report_2014.pdf)
+- Spain: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?name=&defaultValue=false&viewType=TABLE&areaType=BZN&atch=false&dateTime.dateTime=01.01.2017+00:00|UTC|YEAR&dateTime.endDateTime=01.01.2017+00:00|UTC|YEAR&area.values=CTY|10YES-REE------0!BZN|10YES-REE------0&productionType.values=B01&productionType.values=B02&productionType.values=B03&productionType.values=B04&productionType.values=B05&productionType.values=B06&productionType.values=B07&productionType.values=B08&productionType.values=B09&productionType.values=B10&productionType.values=B11&productionType.values=B12&productionType.values=B13&productionType.values=B14&productionType.values=B20&productionType.values=B15&productionType.values=B16&productionType.values=B17&productionType.values=B18&productionType.values=B19)
 - Sweden: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Switzerland: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - United States of America [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)

--- a/config/capacities.json
+++ b/config/capacities.json
@@ -133,17 +133,17 @@
     },
     "ES": {
         "capacity": {
-	    "biomass": 1077,
+	        "biomass": 1077,
             "coal": 9535,
             "gas": 30723,
             "hydro": 20269,
-	    "hydro storage": 5645,
+	        "hydro storage": 5645,
             "nuclear": 7572,
-	    "oil": 715,
+	        "oil": 715,
             "solar": 6720,
             "wind": 22813,
-	    "geothermal": 0,
-	    "unknown": 360
+	        "geothermal": 0,
+	        "unknown": 360
         }
     },
     "FI": {

--- a/config/capacities.json
+++ b/config/capacities.json
@@ -133,12 +133,17 @@
     },
     "ES": {
         "capacity": {
-            "coal": 11482,
-            "gas": 30704,
-            "hydro": 19893,
-            "nuclear": 7866,
-            "solar": 6972,
-            "wind": 23002
+	    "biomass": 1077,
+            "coal": 9535,
+            "gas": 30723,
+            "hydro": 20269,
+	    "hydro storage": 5645,
+            "nuclear": 7572,
+	    "oil": 715,
+            "solar": 6720,
+            "wind": 22813,
+	    "geothermal": 0,
+	    "unknown": 360
         }
     },
     "FI": {


### PR DESCRIPTION
Update Spain production capacity from [ENTSO-E data](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?name=&defaultValue=false&viewType=TABLE&areaType=BZN&atch=false&dateTime.dateTime=01.01.2017+00:00|UTC|YEAR&dateTime.endDateTime=01.01.2017+00:00|UTC|YEAR&area.values=CTY|10YES-REE------0!BZN|10YES-REE------0&productionType.values=B01&productionType.values=B02&productionType.values=B03&productionType.values=B04&productionType.values=B05&productionType.values=B06&productionType.values=B07&productionType.values=B08&productionType.values=B09&productionType.values=B10&productionType.values=B11&productionType.values=B12&productionType.values=B13&productionType.values=B14&productionType.values=B20&productionType.values=B15&productionType.values=B16&productionType.values=B17&productionType.values=B18&productionType.values=B19)