### PR TITLE
UY parser improvements

### DIFF
--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -47,7 +47,18 @@ def parse_page(session):
         value = tds[1].find_all('b')
         # Go back one level up if the b tag is not there
         if not len(value): value = tds[1].find_all('font')
-        v = float(value[0].contents[0].replace(',', '.'))
+        v_str = value[0].contents[0]
+        if v_str.find(',') > -1 and v_str.find('.') > -1:
+            # there can be values like "1.012,5"
+            v_str = v_str.replace('.', '')
+            v_str = v_str.replace(',', '.')
+        else:
+            # just replace decimal separator, like "125,2"
+            v_str = v_str.replace(',', '.')
+        v = float(v_str)
+
+        # solar reports -0.1 at night, make it at least 0
+        v = max(v, 0)
 
         obj[k] = v
 


### PR DESCRIPTION
This should fix #603, as well as a parse error I was getting when hydro is above 1 GW, due to the number being formatted like "1.040,7":

![screenshot - 090717 - 18 27 05](https://user-images.githubusercontent.com/47415/27995787-a37f3986-64d4-11e7-8f1b-cf4f95679db7.png)

On master branch right now I would get the error:

    ValueError: invalid literal for float(): 1.040.7
