### PR TITLE
Remove special cases in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,18 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
-end_of_line = lf
+indent_size = 4
+end_of_line = crlf
 insert_final_newline = true
-
-[*.js]
-indent_style = space
-indent_size = 4
-end_of_line = lf
-insert_final_newline = true
-
-[*.json]
-indent_size = 4
-
-[*.py]
-indent_size = 4
+charset = utf-8


### PR DESCRIPTION
All files are using 4 spaces as indent, and is is no reason to specify that for each file type