### PR TITLE
Fix Balearic Islands parser

### DIFF
--- a/parsers/ES_IB.py
+++ b/parsers/ES_IB.py
@@ -46,7 +46,7 @@ def fetch_production(country_code='ES-IB', session=None):
                 'unknown': response.unknown()
             },
             'storage': {
-                'hydro': response.storage
+                'hydro': 0.0
             },
             'source': 'demanda.ree.es',
         }


### PR DESCRIPTION
Fix Balearic Islands parser, currently isn't working.

Storage response property is removed in the reescraper version 1.4.0  and the Balearic Islands don't have storage systems. 