### PR TITLE
Fixed BG.py return python datetime instead of Arrow

### DIFF
--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -110,7 +110,7 @@ def fetch_production(country_code='BG', session=None):
         },
         'storage': {},
         'source': 'tso.bg',
-        'datetime': datetime
+        'datetime': datetime.datetime
     }
 
     return data


### PR DESCRIPTION
same issue as Bulgaria, I returned an arrow object. fixed now