### PR TITLE
Bugfix that causes solar values not to be read

### DIFF
--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -14,7 +14,7 @@ TYPE_MAPPING = {                        # Real values around midnight
     u'ВЕЦ': 'hydro',                    # 7
     u'Малки ВЕЦ': 'hydro',              # 74
     u'ВяЕЦ': 'wind',                    # 488
-    u'ФЕЦ': 'sun',                      # 0
+    u'ФЕЦ': 'solar',                    # 0
     u'Био ТЕЦ': 'biomass',              # 29
     u'Товар РБ': 'consumption',         # 3175
 }


### PR DESCRIPTION
Following a discussion with Olivier Corradi and Julian Popov on why solar power in Bulgaria is not displayed on the map.