### PR TITLE
Add Brazil

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/corrad
 - Bosnia and Herzegovina: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - Bolivia: [CNDC](http://www.cndc.bo/media/archivos/graf/gene_hora/gweb_despdia_genera.php)
 - Belgium: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
+- Brazil: [ONS](http://www.ons.org.br/pt/paginas/energia-agora/carga-e-geracao)
 - Bulgaria: [TSO](http://tso.bg/default.aspx/page-707/bg)
 - Canada (Alberta): [AESO](http://ets.aeso.ca/ets_web/ip/Market/Reports/CSDReportServlet)
 - Canada (New Brunswick): [NB Power](https://tso.nbpower.com/Public/en/op/market/data.aspx)
@@ -112,6 +113,7 @@ Production capacities are centralized in the [capacities.json](https://github.co
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Belgium: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Bolivia: [CNDC](http://www.cndc.bo/agentes/generacion.php)
+- Brazil: [ONS](http://www.ons.org.br/Paginas/resultados-da-operacao/historico-da-operacao/capacidade_instalada.aspx)
 - Bulgaria: [wikipedia.org](https://en.wikipedia.org/wiki/Energy_in_Bulgaria)
 - Canada (British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island):
     [wikipedia.org](https://en.wikipedia.org/wiki/List_of_generating_stations_in_Canada)
@@ -146,7 +148,7 @@ Production capacities are centralized in the [capacities.json](https://github.co
   - Solar: [wikipedia.org](https://en.wikipedia.org/wiki/Electricity_sector_in_Italy)
   - Wind: [wikipedia.org](https://en.wikipedia.org/wiki/Electricity_sector_in_Italy)
 - India (Andhra Pradesh): [wikipedia.org](https://en.wikipedia.org/wiki/Power_sector_of_Andhra_Pradesh)
-- India (Karnataka): 
+- India (Karnataka):
   - Coal: [kptclsldc.com](http://kptclsldc.com/StateGen.aspx)
   - Hydro: [kptclsldc.com](http://kptclsldc.com/StateGen.aspx)
   - Renewables [kptclsldc.com](http://kptclsldc.com/StateNCEP.aspx)

--- a/config/zones.json
+++ b/config/zones.json
@@ -119,11 +119,23 @@
     "capacity": {
       "hydro": 483.22,
       "unknown" : 1344.55,
-      "wind": 27 
+      "wind": 27
     },
     "parsers": {
       "production": "BO.fetch_production",
       "generationForecast": "BO.fetch_generation_forecast"
+    }
+  },
+  "BR": {
+    "capacity": {
+      "thermal": 33807,
+      "hydro": 102573,
+      "nuclear": 1990,
+      "solar": 69,
+      "wind": 10196
+    },
+    "parsers": {
+      "production": "BR.fetch_production"
     }
   },
   "BY": {},
@@ -877,7 +889,7 @@
     "parsers": {
       "production": "SV.fetch_production"
     }
-  },    
+  },
   "TR": {
     "parsers": {
       "production": "TR.fetch_production"

--- a/parsers/BR.py
+++ b/parsers/BR.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+
+import arrow
+from collections import defaultdict
+import requests
+
+url ='http://tr.ons.org.br/Content/GetBalancoEnergetico/null'
+
+generation_mapping = {
+                      u'nuclear': 'nuclear',
+                      u'eolica': 'wind',
+                      u'termica': 'unknown',
+                      u'solar': 'solar',
+                      'hydro' : 'hydro'
+                      }
+
+regions = [u'nordeste', u'norte', u'sudesteECentroOeste', u'sul']
+
+
+def get_data(session = None):
+    """Requests generation data in json format."""
+
+    s = session or requests.session()
+    json_data = s.get(url).json()
+
+    return json_data
+
+
+def production_processor(json_data):
+    """
+    Extracts data timestamp and sums regional data into totals by key.
+    Maps keys to type and returns a tuple.
+    """
+
+    dt = arrow.get(json_data['Data'])
+    totals = defaultdict(lambda: 0.0)
+
+    for region in regions:
+        breakdown = json_data[region][u'geracao']
+        for generation, val in breakdown.items():
+            totals[generation] += val
+
+    #We merge the 3 hydro keys into one, then remove unnecessary keys.
+    totals['hydro'] = totals[u'hidraulica'] + totals[u'itaipu50HzBrasil'] + totals[u'itaipu60Hz']
+    entriesToRemove = (u'hidraulica', u'itaipu50HzBrasil', u'itaipu60Hz', u'total')
+    for k in entriesToRemove:
+        totals.pop(k, None)
+
+    mapped_totals = {generation_mapping.get(name, 'unknown'): val for name, val in totals.items()}
+
+    return dt, mapped_totals
+
+
+def fetch_production(country_code = 'BR', session = None):
+    """
+    Requests the last known production mix (in MW) of a given country
+    Arguments:
+    country_code (optional) -- used in case a parser is able to fetch multiple countries
+    session (optional)      -- request session passed in order to re-use an existing session
+    Return:
+    A dictionary in the form:
+    {
+      'countryCode': 'FR',
+      'datetime': '2017-01-01T00:00:00Z',
+      'production': {
+          'biomass': 0.0,
+          'coal': 0.0,
+          'gas': 0.0,
+          'hydro': 0.0,
+          'nuclear': null,
+          'oil': 0.0,
+          'solar': 0.0,
+          'wind': 0.0,
+          'geothermal': 0.0,
+          'unknown': 0.0
+      },
+      'storage': {
+          'hydro': -10.0,
+      },
+      'source': 'mysource.com'
+    }
+    """
+
+    gd = get_data()
+    generation = production_processor(gd)
+
+    datapoint = {
+      'countryCode': country_code,
+      'datetime': generation[0],
+      'production': generation[1],
+      'storage': {
+          'hydro': None,
+      },
+      'source': 'ons.org.br'
+    }
+
+    return datapoint
+
+
+if __name__ ==  '__main__':
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
+
+    print('fetch_production() ->')
+    print(fetch_production())


### PR DESCRIPTION
This is the production parser for Brazil on a country level.  If we want to break generation down by region in the future this can by done quite easily.

I've set the thermal production key to unknown since there is no breakdown by type.  Roughly 60% is oil, 28% biomass, 10% gas with a few coal plants making up the rest.

#695 