### PR TITLE
setting on config the exchange between Brazil and Uruguay

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -235,9 +235,14 @@
     "rotation": -90
   },
   "BR->UY": {
+    "lonlat": [
+       -54.982242,
+       -31.301863
+    ],
     "parsers": {
       "exchange": "BR.fetch_exchange"
-    }
+    },
+    "rotation": -150
   },
   "CA-AB->CA-BC": {
     "lonlat": [


### PR DESCRIPTION
#695 As part of Brazil datasource and the merged exchange parser built in https://github.com/tmrowco/electricitymap/pull/747

This is the setup in config to display the exchanges between Brazil and Uruguay.