### PR TITLE
Revert day format of IN_PB

### DIFF
--- a/parsers/IN_PB.py
+++ b/parsers/IN_PB.py
@@ -95,7 +95,7 @@ def fetch_consumption(country_code='IN-PB', session=None):
     date_text = read_text_by_regex('(\d+/\d+/\d+)', response_text)
     time_text = read_text_by_regex('(\d+:\d+:\d+)', response_text)
     
-    india_date = date_time_strings_to_kolkata_date(date_text, "DD/MM/YYYY", time_text, "HH:mm:ss")
+    india_date = date_time_strings_to_kolkata_date(date_text, "MM/DD/YYYY", time_text, "HH:mm:ss")
 
     punjab_match = search('<tr>(.*?)PUNJAB(.*?)</tr>', response_text, M|I|S).group(0)
     punjab_tr_text = findall('<tr>(.*?)</tr>', punjab_match, M|I|S)[1]

--- a/parsers/test/test_IN_PB.py
+++ b/parsers/test/test_IN_PB.py
@@ -25,7 +25,7 @@ class TestINPB(unittest.TestCase):
             self.assertEqual(data['countryCode'], 'IN-PB')
             self.assertEqual(data['source'], 'punjasldc.org')
             self.assertIsNotNone(data['datetime'])
-            expected = get(datetime(2017, 6, 9, 14, 38, 29), 'Asia/Kolkata').datetime
+            expected = get(datetime(2017, 9, 6, 14, 38, 29), 'Asia/Kolkata').datetime
             date_time = data['datetime']
             self.assertEquals(date_time, expected)
             self.assertIsNotNone(data['consumption'])


### PR DESCRIPTION
In that [commit](https://github.com/tmrowco/electricitymap/commit/43b135bde8a164c3d090d964c4c99e37e4f1f00f), the day format of the Punjab (India) consumption parser was changed to ```DD/MM/YYYY``` but the correct format is ```MM/DD/YYYY```.

It is very rare and it took time to realize when I made the parser.