### PR TITLE
Set nuclear of AT to 0

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -26,7 +26,8 @@
       "hydro": 11054,
       "oil": 288,
       "solar": 814,
-      "wind": 2739
+      "wind": 2739,
+      "nuclear": 0
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",


### PR DESCRIPTION
Austria has no nuclear power plants that have ever generated electricity