### PR TITLE
correct AU exchanges, fix #804

### DIFF
--- a/parsers/AU.py
+++ b/parsers/AU.py
@@ -419,16 +419,21 @@ def fetch_production(country_code=None, session=None):
     return data
 
 
+# It appears that the interconnectors are named according to positive flow.
+# That is, NSW1-QLD1 reports positive values when there is flow from NSW to QLD,
+# and negative values when flow is from QLD to NSW.
+# To verify, compare with flows shown on
+# http://aemo.com.au/Electricity/National-Electricity-Market-NEM/Data-dashboard#nem-dispatch-overview
 EXCHANGE_MAPPING_DICTIONARY = {
     'AUS-NSW->AUS-QLD': {
         'region_id': 'QLD1',
         'interconnector_names': ['N-Q-MNSP1', 'NSW1-QLD1'],
-        'directions': [-1, -1]
+        'directions': [1, 1]
     },
     'AUS-NSW->AUS-VIC': {
         'region_id': 'NSW1',
         'interconnector_names': ['VIC1-NSW1'],
-        'directions': [1]
+        'directions': [-1]
     },
     'AUS-SA->AUS-VIC': {
         'region_id': 'VIC1',


### PR DESCRIPTION
Re: #804

Verify with http://aemo.com.au/Electricity/National-Electricity-Market-NEM/Data-dashboard#nem-dispatch-overview

````
fetch_exchange('AUS-NSW', 'AUS-QLD') ->
{'sortedCountryCodes': 'AUS-NSW->AUS-QLD', 'netFlow': -548.93615, 'datetime': datetime.datetime(2017, 10, 31, 19, 40, tzinfo=tzfile('/usr/share/zoneinfo/Australia/NSW')), 'capacity': [-1170.40387, 332.52477000000005], 'source': 'aemo.com.au'}
fetch_exchange('AUS-NSW', 'AUS-VIC') ->
{'sortedCountryCodes': 'AUS-NSW->AUS-VIC', 'netFlow': 193.86055, 'datetime': datetime.datetime(2017, 10, 31, 19, 40, tzinfo=tzfile('/usr/share/zoneinfo/Australia/NSW')), 'capacity': [-959.77504, 193.86055], 'source': 'aemo.com.au'}
fetch_exchange('AUS-VIC', 'AUS-SA') ->
{'sortedCountryCodes': 'AUS-SA->AUS-VIC', 'netFlow': 143.67065, 'datetime': datetime.datetime(2017, 10, 31, 19, 40, tzinfo=tzfile('/usr/share/zoneinfo/Australia/NSW')), 'capacity': [-573.00003, 599.97101], 'source': 'aemo.com.au'}
fetch_exchange('AUS-VIC', 'AUS-TAS') ->
{'sortedCountryCodes': 'AUS-TAS->AUS-VIC', 'netFlow': 109.1139, 'datetime': datetime.datetime(2017, 10, 31, 19, 40, tzinfo=tzfile('/usr/share/zoneinfo/Australia/NSW')), 'capacity': [109.1155, 286.0], 'source': 'aemo.com.au'}
````

![image](https://user-images.githubusercontent.com/47415/32217561-a7c67cb8-be28-11e7-89a3-86bc502d3337.png)

(Timestamps are off by 5 minutes because we subtract 5 minutes from AEMO reported data because "The chart shows real-time data (5-minute) for each region")