### PR TITLE
increased body font-weight to 300

### DIFF
--- a/web/app/styles.css
+++ b/web/app/styles.css
@@ -20,7 +20,7 @@ html, body {
     font-family: sans-serif;
     background-color: #32414c; /* water color */
     overflow: hidden;
-    font-weight: 100; /* increases clarity */
+    font-weight: 300; /* increases clarity */
 }
 
 hr {


### PR DESCRIPTION
Changed font weight to 300, which is both clear on desktop and on my samsung S7:

Saumsung S7 300
![image](https://user-images.githubusercontent.com/22095643/32384476-4b4a2da0-c0bb-11e7-9fb3-9accc8163f31.png)

Desktop 300
![image](https://user-images.githubusercontent.com/22095643/32384454-3cf3a042-c0bb-11e7-8aec-6b5e49f54143.png)

Initial values  (400) ---->

Samsung S7 400 (default)
![image](https://user-images.githubusercontent.com/22095643/32384526-8338cf78-c0bb-11e7-896d-d18e75297f0c.png)

Desktop 400
![image](https://user-images.githubusercontent.com/22095643/32384646-df3c74fa-c0bb-11e7-85f2-a7f569fd80e6.png)


