### PR TITLE
Fix Punjab parser, to read consumption date in both formats

### DIFF
--- a/parsers/IN_PB.py
+++ b/parsers/IN_PB.py
@@ -18,12 +18,6 @@ def read_text_by_regex(regex, text):
     return date_text
 
 
-def date_time_strings_to_kolkata_date(date_text, date_format, time_text, time_format):
-    date_format = date_format + time_format + 'ZZZ'
-    date_time = date_text + time_text + 'Asia/Kolkata'
-    return get(date_time, date_format)
-
-
 def fetch_production(country_code='IN-PB', session=None):
     """Fetch Punjab production"""
     countrycode.assert_country_code(country_code, 'IN-PB')
@@ -78,6 +72,30 @@ def fetch_production(country_code='IN-PB', session=None):
     return data
 
 
+def read_punjab_consumption_date(date_text, time_text, current):
+    date_time = date_text + time_text + 'Asia/Kolkata'
+
+    dates = []
+    try:
+        mm_dd_yyyy_format_date = get(date_time, "MM/DD/YYYYHH:mm:ssZZZ")
+        if mm_dd_yyyy_format_date and mm_dd_yyyy_format_date < current:
+            dates.append(mm_dd_yyyy_format_date)
+    except ValueError:
+        pass
+
+    try:
+        dd_mm_yyyy_format_date = get(date_time, "DD/MM/YYYYHH:mm:ssZZZ")
+        if dd_mm_yyyy_format_date and dd_mm_yyyy_format_date < current:
+            dates.append(dd_mm_yyyy_format_date)
+    except ValueError:
+        pass
+
+    if len(dates) > 0:
+        return min(dates, key=lambda date: abs(date - current))
+    else:
+        raise Exception('IN-PB', 'Can''t read Punjab consumption date. DateTime String: {0}, Current Date: {1}'.format(date_time, current))
+
+
 def fetch_consumption(country_code='IN-PB', session=None):
     """Fetch Punjab consumption"""
     countrycode.assert_country_code(country_code, 'IN-PB')
@@ -85,8 +103,9 @@ def fetch_consumption(country_code='IN-PB', session=None):
                                           session)
     date_text = read_text_by_regex('(\d+/\d+/\d+)', response_text)
     time_text = read_text_by_regex('(\d+:\d+:\d+)', response_text)
-    
-    india_date = date_time_strings_to_kolkata_date(date_text, "MM/DD/YYYY", time_text, "HH:mm:ss")
+
+    india_current_date = utcnow().to('Asia/Kolkata')
+    india_date = read_punjab_consumption_date(date_text, time_text, india_current_date)
 
     punjab_match = search('<tr>(.*?)PUNJAB(.*?)</tr>', response_text, M|I|S).group(0)
     punjab_tr_text = findall('<tr>(.*?)</tr>', punjab_match, M|I|S)[1]

--- a/parsers/test/test_IN_PB.py
+++ b/parsers/test/test_IN_PB.py
@@ -15,6 +15,19 @@ class TestINPB(unittest.TestCase):
         self.adapter = Adapter()
         self.session.mount('http://', self.adapter)
 
+    def test_read_punjab_consumption_date(self):
+        current = get(datetime(2017, 11, 18, 20, 35, 20), 'Asia/Kolkata')
+        expected = get(datetime(2017, 11, 18, 20, 35, 15), 'Asia/Kolkata')
+        result = IN_PB.read_punjab_consumption_date("18/11/2017", "20:35:15", current)
+        self.assertEqual(expected, result)
+        result = IN_PB.read_punjab_consumption_date("11/18/2017", "20:35:15", current)
+        self.assertEqual(expected, result)
+
+        current = get(datetime(2017, 10, 9, 15, 35, 20), 'Asia/Kolkata')
+        expected = get(datetime(2017, 10, 9, 15, 35, 15), 'Asia/Kolkata')
+        result = IN_PB.read_punjab_consumption_date("10/09/2017", "15:35:15", current)
+        self.assertEqual(expected, result)
+
     def test_fetch_consumption(self):
         response_text = resource_string("parsers.test.mocks", "IN_PB_nrGenReal.html")
         self.adapter.register_uri("GET", "http://www.punjabsldc.org/nrrealw.asp?pg=nrGenReal",
@@ -47,7 +60,7 @@ class TestINPB(unittest.TestCase):
             self.assertEqual(data['production']['hydro'], 554.0)
             self.assertIsNotNone(data['storage'])
         except Exception as ex:
-            self.fail("IN_KA.fetch_production() raised Exception: {0}".format(ex.message))
+            self.fail("IN_PB.fetch_production() raised Exception: {0}".format(ex.message))
 
     def test_read_text_by_regex(self):
         text ='<b><font size="4">&nbsp;09/06/2017</b></font>'
@@ -64,16 +77,6 @@ class TestINPB(unittest.TestCase):
         date_text = IN_PB.read_text_by_regex('(\d+:\d+:\d+)', text)
         expected = "13:33:59"
         self.assertEquals(date_text, expected)
-
-    def test_date_time_strings_to_kolkata_date(self):
-        date_text = "09/06/2017"
-        date_format = "DD/MM/YYYY"
-        time_text = "13:33:59"
-        time_format = "HH:mm:ss"
-        date_time = IN_PB.date_time_strings_to_kolkata_date(date_text, date_format, time_text, time_format)
-        self.assertIsNotNone(date_time)
-        expected = get(datetime(2017, 6, 9, 13, 33, 59), 'Asia/Kolkata')
-        self.assertEquals(date_time, expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix Punjab parser, to read consumption date in both formats, MM/DD/YYYY and DD/MM/YYYY.

It try to fix this [issue](https://github.com/tmrowco/electricitymap/issues/854)