### PR TITLE
some bounding box and entsoe forecast parsers added

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -31,6 +31,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -133,6 +135,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -406,6 +410,7 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
       "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
@@ -478,6 +483,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -486,6 +493,16 @@
     ]
   },
   "DE": {
+    "bounding_box": [
+      [
+        5.8227539063,
+        47.2643200803
+      ],
+      [
+        15.0732421875,
+        55.1537662685
+      ]
+    ],
     "capacity": {
       "biomass": 7060,
       "coal": 49280,
@@ -499,6 +516,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -579,6 +598,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -613,6 +634,7 @@
     "flag_file_name": "es.png",
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
       "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
@@ -666,6 +688,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -687,6 +711,16 @@
     ]
   },
   "FR": {
+    "bounding_box": [
+      [
+        -5.44921875,
+        42.3098154157
+      ],
+      [
+        8.2177734375,
+        51.2894059027
+      ]
+    ],
     "capacity": {
       "coal": 2930,
       "gas": 10909,
@@ -698,6 +732,9 @@
       "wind": 10358
     },
     "parsers": {
+      "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "FR.fetch_price",
       "production": "FR.fetch_production"
     },
@@ -707,6 +744,16 @@
   },
   "GB": {
     "_comment": "incl. 2744 MW storage. Key should be GB-GBN (see https://en.wikipedia.org/wiki/ISO_3166-2:GB)",
+    "bounding_box": [
+      [
+        -8.173828125,
+        49.6462914122
+      ],
+      [
+        2.1533203125,
+        61.0795442346
+      ]
+    ],
     "capacity": {
       "biomass": 2119,
       "coal": 11097,
@@ -721,6 +768,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -764,6 +813,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -806,6 +857,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -828,6 +881,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -933,6 +988,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -951,6 +1008,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -961,6 +1020,8 @@
   "LU": {
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -977,6 +1038,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -992,6 +1055,9 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
+      "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
     "contributors": [
@@ -1044,6 +1110,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1052,6 +1120,16 @@
     ]
   },
   "NO": {
+    "bounding_box": [
+      [
+        4.2626953125,
+        57.7276192162
+      ],
+      [
+        20.1708984375,
+        70.8734913193
+      ]
+    ],
     "capacity": {
       "coal": 0,
       "gas": 611,
@@ -1064,6 +1142,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1113,6 +1193,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1121,6 +1203,16 @@
     ]
   },
   "PT": {
+    "bounding_box": [
+      [
+        -9.8876953125,
+        36.6860412766
+      ],
+      [
+        -6.1743164062,
+        36.6860412766
+      ]
+    ],
     "capacity": {
       "biomass": 598,
       "coal": 1756,
@@ -1135,6 +1227,8 @@
     "flag_file_name": "pt.png",
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1162,6 +1256,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1179,6 +1275,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1204,12 +1302,12 @@
   "SE": {
     "bounding_box": [
       [
-        11.337890625,
-        55.1788676633
+        11.25,
+        55.379110448
       ],
       [
-        24.169921875,
-        68.9741635834
+        21.2255859375,
+        69.0214140884
       ]
     ],
     "capacity": {
@@ -1223,6 +1321,7 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
       "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
@@ -1258,6 +1357,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },
@@ -1278,6 +1379,8 @@
     },
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
+      "consumptionForecast": "ENTSOE.fetch_consumption_forecast",
+      "generationForecast": "ENTSOE.fetch_generation_forecast",
       "price": "ENTSOE.fetch_price",
       "production": "ENTSOE.fetch_production"
     },


### PR DESCRIPTION
Norway square bounding box approximated to try to avoid encapsulating both sweden and finland, in order to better reflect mean value of wind over the country when we will compute it
![image](https://user-images.githubusercontent.com/22095643/33420594-75d888b0-d5af-11e7-95dc-b98e25c0ebae.png)
