### PR TITLE
Fix tooltip display

### DIFF
--- a/web/app/components/tooltip.js
+++ b/web/app/components/tooltip.js
@@ -43,11 +43,9 @@ function Tooltip(selector) {
 
 Tooltip.prototype.show = function() {
     d3.select(this._selector)
+        .style('display', 'block')
         .transition()
-        .style('opacity', 1)
-        .on('end', function() {
-            d3.select(this).style('pointer-events', 'all');
-        });
+        .style('opacity', 1);
     return this;
 }
 Tooltip.prototype.update = function(x, y) {
@@ -59,7 +57,7 @@ Tooltip.prototype.hide = function() {
         .transition()
         .style('opacity', 0)
         .on('end', function() {
-            d3.select(this).style('pointer-events', 'none');
+            d3.select(this).style('display', 'none');
         });
     return this;
 }

--- a/web/app/styles.css
+++ b/web/app/styles.css
@@ -477,6 +477,7 @@ label[for="checkbox-colorblind"] {
 }
 
 .tooltip {
+    display: none;
     border: 1px solid grey;
     color: darkgrey;
     padding: 5px;


### PR DESCRIPTION
This fixes a bug that caused the menu buttons to be unclickable, because the tooltip starts out with with `opacity: 0` but not with `display: none` (hence click events were blocked).

![image](https://user-images.githubusercontent.com/1655848/33421418-398c8674-d5b2-11e7-88b7-34941eaa4417.png)
