### PR TITLE
split CA-ON and update CA-NB exchanges with US

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -385,7 +385,7 @@
     },
     "rotation": -45
   },
-  "CA-NB->US": {
+  "CA-NB->US-NEISO": {
     "lonlat": [
       -67.7771,
       46.139
@@ -405,7 +405,17 @@
     },
     "rotation": 90
   },
-  "CA-ON->US": {
+  "CA-ON->US-MI": {
+    "lonlat": [
+      -82.1195,
+      43.5896
+    ],
+    "parsers": {
+      "exchange": "CA_ON.fetch_exchange"
+    },
+    "rotation": -90
+  },
+  "CA-ON->US-MN": {
     "lonlat": [
       -92.722024,
       48.566155
@@ -414,6 +424,16 @@
       "exchange": "CA_ON.fetch_exchange"
     },
     "rotation": 180
+  },
+  "CA-ON->US-NY": {
+    "lonlat": [
+      -78.9147,
+      43.5523
+    ],
+    "parsers": {
+      "exchange": "CA_ON.fetch_exchange"
+    },
+    "rotation": 135
   },
   "CH->DE": {
     "lonlat": [

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -127,10 +127,10 @@ def fetch_exchange(country_code1, country_code2, session=None):
 
     if sorted_country_codes == 'CA-NB->CA-QC':
         value = flows['QUEBEC']
-    elif sorted_country_codes == 'CA-NB->US':
+    elif sorted_country_codes == 'CA-NB->US-NEISO':
         # all of these exports are to Maine
         # (see https://www.nbpower.com/en/about-us/our-energy/system-map/),
-        # but US is not currently broken down by state
+        # currently this is mapped to ISO-NE
         value = flows['EMEC'] + flows['ISO-NE'] + flows['MPS']
     elif sorted_country_codes == 'CA-NB->CA-NS':
         value = flows['NOVA SCOTIA']

--- a/parsers/CA_ON.py
+++ b/parsers/CA_ON.py
@@ -158,8 +158,14 @@ def fetch_exchange(country_code1, country_code2, session=None):
     if sortedCountryCodes == 'CA-MB->CA-ON':
         keys = ['MANITOBA', 'MANITOBA SK']
         direction = -1
-    elif sortedCountryCodes == 'CA-ON->US':
-        keys = ['MICHIGAN', 'MINNESOTA', 'NEW-YORK']
+    elif sortedCountryCodes == 'CA-ON->US-NY':
+        keys = ['NEW-YORK']
+        direction = 1
+    elif sortedCountryCodes == 'CA-ON->US-MI':
+        keys = ['MICHIGAN']
+        direction = 1
+    elif sortedCountryCodes == 'CA-ON->US-MN':
+        keys = ['MINNESOTA']
         direction = 1
     elif sortedCountryCodes == 'CA-ON->CA-QC':
         keys = filter(lambda k: k[:2] == 'PQ', exchanges.keys())
@@ -182,7 +188,9 @@ def fetch_exchange(country_code1, country_code2, session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
-    print 'fetch_price() ->'
-    print fetch_price()
+    print('fetch_production() ->')
+    print(fetch_production())
+    print('fetch_price() ->')
+    print(fetch_price())
+    print('fetch_exchange("CA-ON", "US-NY") ->')
+    print(fetch_exchange("CA-ON", "US-NY"))


### PR DESCRIPTION
* Split Ontario exchanges into separate items for MI, MN, and NY.
* Changed New Brunswick exchange from generic "US" to US-NEISO
* Did not changed Alberta and B.C. yet because we don't yet have western U.S. figured out

Screenshot from mockserver:

![image](https://user-images.githubusercontent.com/47415/34083214-e051a7f6-e36c-11e7-968a-b47cbcd930d3.png)
