### PR TITLE
Update PL Hydro capacities

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1213,12 +1213,12 @@
     ]
   },
   "PL": {
-    "_comment": "incl. 1170 MW storage",
     "capacity": {
       "biomass": 501,
       "coal": 26308,
       "gas": 1596,
-      "hydro": 2321,
+      "hydro": 552,
+      "hydro storage": 1770,
       "nuclear": 0,
       "oil": 345,
       "solar": 187,


### PR DESCRIPTION
Installed capacity of hydro pumped storage was not displayed, although generation is shown.
Pumped Storage: 1770 MW
Hydro: 552 MW = run-of-river: 396 MW + water reservoir:  156 MW