### PR TITLE
Change wind carbon intensity from 12 to 11

### DIFF
--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -42,7 +42,7 @@ var defaultCo2eqFootprint = { // in gCo2eq/kWh
       'source': defaultCo2eqSource
     },
     'wind': {
-      'value': 12,
+      'value': 11,
       'source': defaultCo2eqSource
     },
     'geothermal': {


### PR DESCRIPTION
Correcting a tiny mistake: IPCC median wind onshore value is 11 gCO2eq/kWh. 12 was for offshore.
We don't distinguish offshore from onshore at the moment, and onshore is 99% of capacity installed globally, so 11 is our best guess.
![ipcc powerplant ghg intensity](https://user-images.githubusercontent.com/22095643/34338580-446c8e74-e96a-11e7-9b43-c797643d0738.PNG)

