### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,13 @@ Head over to [http://localhost:8000/](http://localhost:8000/) and you should see
 Once you're done doing your changes, submit a [pull request](https://help.github.com/articles/using-pull-requests/) to get them integrated into the production version.
 
 ### Updating country capacities
-If you want to update or add production capacities for a country then head over to the [zones file](https://github.com/tmrowco/electricitymap/blob/master/config/zones.json) and make any changes needed.  The zones use ISO 3166-1 codes as identifiers, a list of which can be found [here](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes).
+If you want to update or add production capacities for a country then head over to the [zones file](https://github.com/tmrowco/electricitymap/blob/master/config/zones.json) and make any changes needed.
+The zones use ISO 3166-1 codes as identifiers, a list of which can be found [here](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes).
 
 ### Adding a new country
 It is very simple to add a new country. The Electricity Map backend runs a list of so-called *parsers* every 5min. Those parsers are responsible for fetching the generation mix of a given country (check out the existing list in the [parsers](https://github.com/tmrowco/electricitymap/tree/master/parsers) directory, or look at the [work in progress](https://github.com/tmrowco/electricitymap/issues?q=is%3Aissue+is%3Aopen+label%3Aparser)).
 
-A parser is a python script that is expected to define the method `fetch_production` which returns the production mix at current time, in the format:
+A parser is a python3 script that is expected to define the method `fetch_production` which returns the production mix at current time, in the format:
 
 ```python
 def fetch_production(country_code='FR', session=None):
@@ -301,7 +302,7 @@ pip install -r parsers/requirements.txt
 
 Then, you can run
 ```
-PYTHONPATH=. python mockserver/update_state.py <zone_name>
+PYTHONPATH=. python3 mockserver/update_state.py <zone_name>
 ```
 
 from the root directory, replacing `<zone_name>` by the zone identifier of the parser you want to test. This will fetch production and exchanges and assign it a random carbon intensity value. It should appear on the map as you refresh your local browser.

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,12 @@ stages:
     steps:
       - type: checkout
       - type: shell
+        name: Set Python version
+        command: pyenv global 3.5.2
+      - type: shell
+        name: Upgrade pip
+        command: pip install --upgrade pip
+      - type: shell
         name: Install Docker Compose
         command: pip install docker-compose==1.17.1
       - type: shell
@@ -19,9 +25,15 @@ stages:
         name: Lint
         command: |
           set -exu
-          pip install pylint
+          python --version
+          pip --version
+          pip install flake8 pylint
           sudo apt-get install libxml2-dev
           pip install -r parsers/requirements.txt
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+          # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
           pylint -E parsers/*.py
           python -m unittest discover parsers/test
       - save_cache:

--- a/mockserver/Dockerfile
+++ b/mockserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.6
 WORKDIR /home
 EXPOSE 9000
 ADD server.py server.py

--- a/mockserver/update_state.py
+++ b/mockserver/update_state.py
@@ -1,7 +1,13 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 # This script should be run from the root directory
-import arrow, importlib, json, pprint, sys
+import importlib
+import json
+import pprint
+import sys
 from random import random
+
+import arrow
+
 pp = pprint.PrettyPrinter(indent=2)
 
 # Read parser import list from config jsons
@@ -19,14 +25,17 @@ production_parser = zone_config['parsers']['production']
 exchange_parser_keys = []
 for k in exchanges_config.keys():
     zones = k.split('->')
-    if zone_name in zones: exchange_parser_keys.append(k)
+    if zone_name in zones:
+        exchange_parser_keys.append(k)
 
 # Import / run production parser
-print('Finding and executing %s production parser %s..' % (zone_name, production_parser))
+print('Finding and executing %s production parser %s..' % (zone_name,
+                                                           production_parser))
 mod_name, fun_name = production_parser.split('.')
 mod = importlib.import_module('parsers.%s' % mod_name)
 production = getattr(mod, fun_name)(zone_name)
-if type(production) == list: production = production[-1]
+if type(production) == list:
+    production = production[-1]
 pp.pprint(production)
 
 # Import / run exchange parser(s)
@@ -38,7 +47,8 @@ for k in exchange_parser_keys:
     mod = importlib.import_module('parsers.%s' % mod_name)
     sorted_zone_names = sorted(k.split('->'))
     exchange = getattr(mod, fun_name)(sorted_zone_names[0], sorted_zone_names[1])
-    if type(exchange) == list: exchange = exchange[-1]
+    if type(exchange) == list:
+        exchange = exchange[-1]
     exchanges.append(exchange)
     pp.pprint(exchange)
 
@@ -67,11 +77,11 @@ with open('mockserver/public/v3/state', 'r') as f:
 
         for z in exchange_zone_names:
             other_zone = exchange_zone_names[(exchange_zone_names.index(z) + 1) % 2]
-            if not z in obj['countries']:
+            if z not in obj['countries']:
                 obj['countries'][z] = {}
-            if not 'exchange' in obj['countries'][z]:
+            if 'exchange' not in obj['countries'][z]:
                 obj['countries'][z]['exchange'] = {}
-            if not 'exchangeCo2Intensities' in obj['countries'][z]:
+            if 'exchangeCo2Intensities' not in obj['countries'][z]:
                 obj['countries'][z]['exchangeCo2Intensities'] = {}
             obj['countries'][z]['exchange'][other_zone] = e['netFlow']
             if z == exchange_zone_names[0]:
@@ -83,7 +93,7 @@ with open('mockserver/public/v3/state', 'r') as f:
                 obj['countries'].get(other_zone, {}).get('co2intensity',
                     obj['countries'][z].get('co2intensity', None)) if is_import \
                 else obj['countries'][z].get('co2intensity', None)
-            
+
     # Set state datetime
     obj['datetime'] = production['datetime']
     # Save

--- a/mockserver/update_state.py
+++ b/mockserver/update_state.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This script should be run from the root directory
 import arrow, importlib, json, pprint, sys
 from random import random
@@ -21,7 +22,7 @@ for k in exchanges_config.keys():
     if zone_name in zones: exchange_parser_keys.append(k)
 
 # Import / run production parser
-print 'Finding and executing %s production parser %s..' % (zone_name, production_parser)
+print('Finding and executing %s production parser %s..' % (zone_name, production_parser))
 mod_name, fun_name = production_parser.split('.')
 mod = importlib.import_module('parsers.%s' % mod_name)
 production = getattr(mod, fun_name)(zone_name)
@@ -32,7 +33,7 @@ pp.pprint(production)
 exchanges = []
 for k in exchange_parser_keys:
     exchange_parser = exchanges_config[k]['parsers']['exchange']
-    print 'Finding and executing %s exchange parser %s..' % (k, exchange_parser)
+    print('Finding and executing %s exchange parser %s..' % (k, exchange_parser))
     mod_name, fun_name = exchange_parser.split('.')
     mod = importlib.import_module('parsers.%s' % mod_name)
     sorted_zone_names = sorted(k.split('->'))
@@ -42,7 +43,7 @@ for k in exchange_parser_keys:
     pp.pprint(exchange)
 
 # Load and update state
-print 'Updating and writing state..'
+print('Updating and writing state..')
 with open('mockserver/public/v3/state', 'r') as f:
     obj = json.load(f)['data']
     obj['countries'][zone_name] = {}
@@ -88,4 +89,4 @@ with open('mockserver/public/v3/state', 'r') as f:
     # Save
 with open('mockserver/public/v3/state', 'w') as f:
     json.dump({'data': obj}, f)
-print '..done'
+print('..done')

--- a/parsers/AR.py
+++ b/parsers/AR.py
@@ -1,11 +1,17 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import arrow
 import string
 import requests
 from bs4 import BeautifulSoup
 import re
 import itertools
+
+try:
+    unicode         # Python 2
+except NameError:
+    unicode = str   # Python 3
 
 
 #This parser gets hourly electricity generation data from portalweb.cammesa.com/Memnet1/default.aspx
@@ -533,7 +539,7 @@ def fetch_price(country_code='AR', session = None):
         rprice = lprice.split('[')[0]
         price = float(rprice.replace(',','.'))
 
-    except AttributeError, ValueError:
+    except AttributeError as ValueError:
         #Price element not present or no price stated.
         price = None
 
@@ -623,7 +629,7 @@ def get_thermal(session=None):
         try:
             #avoids including titles and headings
             if all((item.isupper(), not item.isalpha(), not ' ' in item)):
-                print '{} is missing from the AR plant mapping!'.format(item)
+                print('{} is missing from the AR plant mapping!'.format(item))
         except AttributeError:
             #not a string....
             continue

--- a/parsers/AU.py
+++ b/parsers/AU.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function
+#!/usr/bin/env python3
 
 import json
 

--- a/parsers/AU.py
+++ b/parsers/AU.py
@@ -1,14 +1,15 @@
+from __future__ import absolute_import, print_function
+
+import json
+
 # The arrow library is used to handle datetimes
 import arrow
+import numpy as np
+import pandas as pd
 # The request library is used to fetch content through HTTP
 import requests
 
-import json
-import numpy as np
-import pandas as pd
-
-from lib import AU_solar, AU_battery
-
+from .lib import AU_battery, AU_solar
 
 AMEO_CATEGORY_DICTIONARY = {
     'Bagasse': 'biomass',
@@ -79,7 +80,7 @@ AMEO_LOCATION_DICTIONARY = {
   'Callide B Power Station': 'AUS-QLD',
   'Capital Wind Farm': 'AUS-NSW',
   'Catagunya Diesel Generation ': 'AUS-TAS',
-  'Cathedral Rocks Wind Farm':  'AUS-SA',
+  'Cathedral Rocks Wind Farm': 'AUS-SA',
   'Coonooer Bridge Wind Farm': 'AUS-VIC',
   'Capital East Solar Farm': 'AUS-NSW',
   'Cethana Power Station': 'AUS-TAS',
@@ -126,7 +127,7 @@ AMEO_LOCATION_DICTIONARY = {
   'Highbury Landfill Gas Power Station Unit 1': 'AUS-SA',
   'Hume Power Station': 'AUS-NSW',
   'Hunter Valley Gas Turbine': 'AUS-NSW',
-  'Hazelwood Power Station': None, # Closed
+  'Hazelwood Power Station': None,  # Closed
   'ISIS Central Sugar Mill Co-generation Plant': 'AUS-QLD',
   'Invicta Sugar Mill': 'AUS-QLD',
   'Jacks Gully Landfill Gas Power Station': 'AUS-NSW',
@@ -178,7 +179,7 @@ AMEO_LOCATION_DICTIONARY = {
   'North Brown Hill Wind Farm': 'AUS-SA',
   'Nine Network Willoughby Plant': 'AUS-NSW',
   'Newport Power Station': 'AUS-VIC',
-  'Northern Power Station': None, # Closed
+  'Northern Power Station': None,  # Closed
   'Nyngan Solar Plant': 'AUS-NSW',
   'Oakey Power Station': 'AUS-QLD',
   'Oaklands Hill Wind Farm': 'AUS-VIC',
@@ -188,7 +189,7 @@ AMEO_LOCATION_DICTIONARY = {
   'Paloona Power Station': 'AUS-TAS',
   'Pedler Creek Landfill Gas Power Station Units 1-3': 'AUS-SA',
   'Pindari Hydro Power Station': 'AUS-NSW',
-  'Playford B Power Station': None, # Closed
+  'Playford B Power Station': None,  # Closed
   'Poatina Power Station': 'AUS-TAS',
   'Port Lincoln Gas Turbine': 'AUS-SA',
   'Port Latta Diesel Generation': 'AUS-TAS',
@@ -266,7 +267,7 @@ AMEO_LOCATION_DICTIONARY = {
   'West Nowra Landfill Gas Power Generation Facility': 'AUS-NSW',
   'Wollert Renewable Energy Facility': 'AUS-SA',
   'Wonthaggi Wind Farm': 'AUS-VIC',
-  'Woodlawn Wind Farm':  'AUS-NSW',
+  'Woodlawn Wind Farm': 'AUS-NSW',
   'Woolnorth Studland Bay / Bluff Point Wind Farm': 'AUS-TAS',
   'Woy Woy Landfill Site': 'AUS-NSW',
   'Wattle Point Wind Farm': 'AUS-VIC',
@@ -417,7 +418,7 @@ def fetch_production(country_code=None, session=None):
         data['production']['solar'] = data['production'].get('solar', 0) + distributed_solar_production
 
     if country_code == 'AUS-SA':
-        #Get South Australia battery status.
+        # Get South Australia battery status.
         data['storage']['battery'] = AU_battery.fetch_SA_battery()
 
     return data
@@ -475,9 +476,8 @@ def fetch_exchange(country_code1=None, country_code2=None, session=None):
     r = session or requests.session()
     url = 'https://www.aemo.com.au/aemo/apps/api/report/ELEC_NEM_SUMMARY'
     response = r.get(url)
-    obj = filter(
-        lambda o: o['REGIONID'] == mapping['region_id'],
-        response.json()['ELEC_NEM_SUMMARY'])[0]
+    obj = list(filter(lambda o: o['REGIONID'] == mapping['region_id'],
+                      response.json()['ELEC_NEM_SUMMARY']))[0]
 
     flows = json.loads(obj['INTERCONNECTORFLOWS'])
     netFlow = 0
@@ -485,7 +485,7 @@ def fetch_exchange(country_code1=None, country_code2=None, session=None):
     exportCapacity = 0
     for i in range(len(mapping['interconnector_names'])):
         interconnector_name = mapping['interconnector_names'][i]
-        interconnector = filter(lambda f: f['name'] == interconnector_name, flows)[0]
+        interconnector = list(filter(lambda f: f['name'] == interconnector_name, flows))[0]
         direction = mapping['directions'][i]
         netFlow += direction * interconnector['value']
         importCapacity += direction * interconnector['importlimit' if direction == 1 else 'exportlimit']
@@ -494,7 +494,7 @@ def fetch_exchange(country_code1=None, country_code2=None, session=None):
     data = {
         'sortedCountryCodes': sorted_country_codes,
         'netFlow': netFlow,
-        'capacity': [importCapacity, exportCapacity], # first one should be negative
+        'capacity': [importCapacity, exportCapacity],  # first one should be negative
         'source': 'aemo.com.au',
         'datetime': arrow.get(arrow.get(obj['SETTLEMENTDATE']).datetime, 'Australia/NSW').replace(minutes=-5).datetime
     }
@@ -505,7 +505,7 @@ def fetch_exchange(country_code1=None, country_code2=None, session=None):
 PRICE_MAPPING_DICTIONARY = {
     'AUS-NSW': 'NSW1',
     'AUS-QLD': 'QLD1',
-    'AUS-SA':  'SA1',
+    'AUS-SA': 'SA1',
     'AUS-TAS': 'TAS1',
     'AUS-VIC': 'VIC1',
 }
@@ -532,9 +532,9 @@ def fetch_price(country_code=None, session=None):
     r = session or requests.session()
     url = 'https://www.aemo.com.au/aemo/apps/api/report/ELEC_NEM_SUMMARY'
     response = r.get(url)
-    obj = filter(
-        lambda o: o['REGIONID'] == PRICE_MAPPING_DICTIONARY[country_code],
-        response.json()['ELEC_NEM_SUMMARY'])[0]
+    obj = list(filter(lambda o:
+                      o['REGIONID'] == PRICE_MAPPING_DICTIONARY[country_code],
+                      response.json()['ELEC_NEM_SUMMARY']))[0]
 
     data = {
         'countryCode': country_code,

--- a/parsers/AU_WA.py
+++ b/parsers/AU_WA.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import datetime
 
 import arrow
 import requests
 import pandas as pd
 
-from lib import AU_solar
+from .lib import AU_solar
 
 
 timezone = 'Australia/Perth'

--- a/parsers/AU_WA.py
+++ b/parsers/AU_WA.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
-from __future__ import absolute_import
+#!/usr/bin/env python3
+
 import datetime
 
 import arrow
@@ -19,20 +19,27 @@ def fetch_production(country_code='AUS-WA', session=None):
 
     # explicitly request last 24 hours, to work around daybreaks in solar API
     allSolar = AU_solar.fetch_solar_all(session, HOURS_TO_GET)
-   
+
     urlMeta = 'http://wa.aemo.com.au/aemo/data/wa/infographic/facility-meta.csv'
     dfFacilityMeta = pd.read_csv(urlMeta)
-    dfFacilityMeta = dfFacilityMeta.drop(['PARTICIPANT_CODE','FACILITY_TYPE','ALTERNATE_FUEL','GENERATION_TYPE','YEAR_COMMISSIONED','YEAR_COMMISSIONED','REGISTRATION_DATE','CAPACITY_CREDITS','RAMP_UP','RAMP_DOWN','AS_AT'],axis=1)
-        
+    dfFacilityMeta = dfFacilityMeta.drop(['PARTICIPANT_CODE', 'FACILITY_TYPE',
+                                          'ALTERNATE_FUEL', 'GENERATION_TYPE',
+                                          'YEAR_COMMISSIONED', 'YEAR_COMMISSIONED',
+                                          'REGISTRATION_DATE', 'CAPACITY_CREDITS',
+                                          'RAMP_UP', 'RAMP_DOWN', 'AS_AT'], axis=1)
+
     urlIntervals = 'http://wa.aemo.com.au/aemo/data/wa/infographic/facility-intervals-last96.csv'
     dfFacilityIntervals = pd.read_csv(urlIntervals)
-    dfFacilityIntervals = dfFacilityIntervals.drop(['PARTICIPANT_CODE','PCT_ALT_FUEL','PEAK_MW','OUTAGE_MW','PEAK_OUTAGE_MW','INTERVALS_GENERATING','TOTAL_INTERVALS','PCT_GENERATING','AS_AT'],axis=1)
+    dfFacilityIntervals = dfFacilityIntervals.drop(['PARTICIPANT_CODE', 'PCT_ALT_FUEL',
+                                                    'PEAK_MW', 'OUTAGE_MW', 'PEAK_OUTAGE_MW',
+                                                    'INTERVALS_GENERATING', 'TOTAL_INTERVALS',
+                                                    'PCT_GENERATING', 'AS_AT'], axis=1)
 
-    dfCombined = pd.merge(dfFacilityMeta,dfFacilityIntervals, how='right', on='FACILITY_CODE')
+    dfCombined = pd.merge(dfFacilityMeta, dfFacilityIntervals, how='right', on='FACILITY_CODE')
     dfCombined['PERIOD'] = pd.to_datetime(dfCombined['PERIOD'])
     dfCombined['ACTUAL_MW'] = pd.to_numeric(dfCombined['ACTUAL_MW'])
     dfCombined['POTENTIAL_MWH'] = pd.to_numeric(dfCombined['POTENTIAL_MWH'])
-    
+
     ts = dfCombined.PERIOD.unique()
     now = arrow.now().datetime
 
@@ -79,6 +86,7 @@ def fetch_production(country_code='AUS-WA', session=None):
         result.append(data)
 
     return result
+
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""

--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -1,6 +1,5 @@
-# encoding=utf8
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 import requests
@@ -18,13 +17,15 @@ TYPE_MAPPING = {                        # Real values around midnight
     u'Товар РБ': 'consumption',         # 3175
 }
 
+
 def time_string_converter(ts):
     """Converts time strings into aware datetime objects."""
 
     dt_naive = arrow.get(ts, 'DD.MM.YYYY HH:mm:ss')
-    dt_aware = dt_naive.replace(tzinfo = 'Europe/Sofia').datetime
+    dt_aware = dt_naive.replace(tzinfo='Europe/Sofia').datetime
 
     return dt_aware
+
 
 def fetch_production(country_code='BG', session=None):
     """Requests the last known production mix (in MW) of a given country
@@ -84,7 +85,7 @@ def fetch_production(country_code='BG', session=None):
         datapoints.append((TYPE_MAPPING[gen], val))
 
     production = {}
-    for k,v in datapoints:
+    for k, v in datapoints:
         production[k] = production.get(k, 0.0) + v
 
     data = {
@@ -93,7 +94,7 @@ def fetch_production(country_code='BG', session=None):
         'storage': {},
         'source': 'eso.bg',
         'datetime': dt
-        }
+    }
 
     return data
 

--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -1,5 +1,6 @@
 # encoding=utf8
 
+from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 import requests
@@ -100,5 +101,5 @@ def fetch_production(country_code='BG', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
+    print('fetch_production() ->')
+    print(fetch_production())

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -19,11 +20,11 @@ MAP_GENERATION = {
 
 def webparser(resp):
     """Takes content from the corresponding webpage and returns the necessary outputs in a dataframe"""
-    #get the response as an html
+    # get the response as an html
     soup = BeautifulSoup(resp.text, 'html.parser')
-    #Each variable correspond to a row
+    # Each variable correspond to a row
     rows = soup.find_all("row")
-    #Extract the name of variables and position
+    # Extract the name of variables and position
     variables = []
     corresponding_row = []
     hours = []
@@ -34,116 +35,116 @@ def webparser(resp):
                 corresponding_row.append(i_row)
             else:
                 hours.append(int(tag.get_text()))
-    #Define output frame
-    obj = pd.DataFrame(0, index = range(24), columns = ['hour'] + variables)
-    #Fill it with hours and variables' value
-    obj.hour= hours
+    # Define output frame
+    obj = pd.DataFrame(0, index=range(24), columns=['hour'] + variables)
+    # Fill it with hours and variables' value
+    obj.hour = hours
     for i_row, row in enumerate(corresponding_row):
         numbers = [float(numb.text) for numb in rows[row].find_all("number")]
         for i_num, num in enumerate(numbers):
-            obj.loc[i_num,(variables[i_row])] = num
-    #Define negative values to NaN
-    obj[obj<0] = 0
-    
+            obj.loc[i_num, (variables[i_row])] = num
+    # Define negative values to NaN
+    obj[obj < 0] = 0
+
     return obj
 
 
-def fetch_hourly_production(country_code, obj, hour, date):          
-    #output frame
+def fetch_hourly_production(country_code, obj, hour, date):
+    # output frame
     data = {
         'countryCode': country_code,
         'production': {},
         'storage': {},
         'source': 'cndc.bo',
     }
-    
-    #Fill datetime variable
-    data['datetime'] = arrow.get(date, 'YYYY-MM-DD').replace(tzinfo=tz_bo, hour=hour).datetime   
-    #Datetime are recorded from hour 1 to 24 in the web service
+
+    # Fill datetime variable
+    data['datetime'] = arrow.get(date, 'YYYY-MM-DD').replace(tzinfo=tz_bo, hour=hour).datetime
+    # Datetime are recorded from hour 1 to 24 in the web service
     if hour == 0:
         hour = 24
-    #Fill production types
-    for i_type in MAP_GENERATION.keys(): 
+    # Fill production types
+    for i_type in MAP_GENERATION.keys():
         data['production'][i_type] = obj[MAP_GENERATION[i_type]][obj.hour == hour].iloc[0]
-    
+
     return data
 
 
 def fetch_production(country_code='BO', session=None):
-    #Define actual and last day (for midnight data)
+    # Define actual and last day (for midnight data)
     now = arrow.now(tz=tz_bo)
     formatted_date = now.format('YYYY-MM-DD')
     past_formatted_date = arrow.get(formatted_date, 'YYYY-MM-DD').shift(days=-1).format('YYYY-MM-DD')
 
-    #Define output frame
+    # Define output frame
     actual_hour = now.hour
-    data = [dict() for h in range(actual_hour+1)]
-    
-    #initial path for url to request
-    url_init = 'http://www.cndc.bo/media/archivos/graf/gene_hora/despacho_diario.php?fechag=' 
+    data = [dict() for h in range(actual_hour + 1)]
 
-    #Start with data for midnight
+    # initial path for url to request
+    url_init = 'http://www.cndc.bo/media/archivos/graf/gene_hora/despacho_diario.php?fechag='
+
+    # Start with data for midnight
     url = url_init + past_formatted_date
-    #Request and rearange in DF
+    # Request and rearange in DF
     r = session or requests.session()
     response = r.get(url)
     obj = webparser(response)
     data_temp = fetch_hourly_production(country_code, obj, 0, formatted_date)
     data[0] = data_temp
-    
-    #Fill data for the other hours until actual hour
-    if actual_hour>1:
+
+    # Fill data for the other hours until actual hour
+    if actual_hour > 1:
         url = url_init + formatted_date
-        #Request and rearange in DF
+        # Request and rearange in DF
         r = session or requests.session()
         response = r.get(url)
         obj = webparser(response)
-        for h in range(1, actual_hour+1):
+        for h in range(1, actual_hour + 1):
             data_temp = fetch_hourly_production(country_code, obj, h, formatted_date)
             data[h] = data_temp
 
     return data
-    
+
 
 def fetch_hourly_generation_forecast(country_code, obj, hour, date):
-    #output frame
+    # output frame
     data = {
         'countryCode': country_code,
         'value': {},
         'source': 'cndc.bo',
     }
-    
-    #Fill forecasted value
+
+    # Fill forecasted value
     data['value'] = obj['Gen.Prevista'][obj.hour == hour].iloc[0]
-    
-    #Fill datetime variable - changing format if midnight (datetime are recorded from hour 1 to 24 in the webservice)
+
+    # Fill datetime variable - changing format if midnight (datetime are recorded from hour 1 to 24 in the webservice)
     if hour == 24:
         hour = 0
         date = arrow.get(date, 'YYYY-MM-DD').shift(days=+1).format('YYYY-MM-DD')
-    data['datetime'] = arrow.get(date, 'YYYY-MM-DD').replace(tzinfo=tz_bo, hour=hour).datetime   
-    
+    data['datetime'] = arrow.get(date, 'YYYY-MM-DD').replace(tzinfo=tz_bo, hour=hour).datetime
+
     return data
 
 
-def fetch_generation_forecast(country_code = 'BO', session=None):
-    #Define actual and last day (for midnight data)
+def fetch_generation_forecast(country_code='BO', session=None):
+    # Define actual and last day (for midnight data)
     formatted_date = arrow.now(tz=tz_bo).format('YYYY-MM-DD')
-    
-    #Define output frame
+
+    # Define output frame
     data = [dict() for h in range(24)]
 
-    #initial path for url to request
-    url_init = 'http://www.cndc.bo/media/archivos/graf/gene_hora/despacho_diario.php?fechag=' 
+    # initial path for url to request
+    url_init = 'http://www.cndc.bo/media/archivos/graf/gene_hora/despacho_diario.php?fechag='
     url = url_init + formatted_date
-    
-    #Request and rearange in DF
+
+    # Request and rearange in DF
     r = session or requests.session()
     response = r.get(url)
     obj = webparser(response)
-    
-    for h in range(1,25):
+
+    for h in range(1, 25):
         data_temp = fetch_hourly_generation_forecast('BO', obj, h, formatted_date)
-        data[h-1] = data_temp
+        data[h - 1] = data_temp
 
     return data
 

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -149,7 +150,7 @@ def fetch_generation_forecast(country_code = 'BO', session=None):
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
-    print 'fetch_production() ->'
-    print fetch_production()
-    print 'fetch_generation_forecast() ->'
-    print fetch_generation_forecast()
+    print('fetch_production() ->')
+    print(fetch_production())
+    print('fetch_generation_forecast() ->')
+    print(fetch_generation_forecast())

--- a/parsers/BR.py
+++ b/parsers/BR.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 
+from __future__ import print_function
 import arrow
 from collections import defaultdict
 import requests

--- a/parsers/BR.py
+++ b/parsers/BR.py
@@ -1,18 +1,17 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 from collections import defaultdict
 import requests
 
-url ='http://tr.ons.org.br/Content/GetBalancoEnergetico/null'
+url = 'http://tr.ons.org.br/Content/GetBalancoEnergetico/null'
 
 generation_mapping = {
                       u'nuclear': 'nuclear',
                       u'eolica': 'wind',
                       u'termica': 'unknown',
                       u'solar': 'solar',
-                      'hydro' : 'hydro'
+                      'hydro': 'hydro'
                       }
 
 regions = {
@@ -24,8 +23,8 @@ regions = {
 
 region_exchanges = {
                     'BR-CS->BR-S': "sul_sudeste",
-                    'BR-CS->BR-NE':"sudeste_nordeste",
-                    'BR-CS->BR-N':"sudeste_norteFic",
+                    'BR-CS->BR-NE': "sudeste_nordeste",
+                    'BR-CS->BR-N': "sudeste_norteFic",
                     'BR-N->BR-NE': "norteFic_nordeste"
                     }
 
@@ -53,7 +52,7 @@ countries_exchange = {
 }
 
 
-def get_data(session = None):
+def get_data(session=None):
     """Requests generation data in json format."""
 
     s = session or requests.session()
@@ -75,7 +74,7 @@ def production_processor(json_data, country_code):
     breakdown = json_data[region][u'geracao']
     for generation, val in breakdown.items():
         # tolerance range
-        if  -1 <= totals['solar'] < 0:
+        if -1 <= totals['solar'] < 0:
             totals['solar'] = 0.0
 
         # not tolerance range
@@ -84,19 +83,20 @@ def production_processor(json_data, country_code):
 
         totals[generation] += val
 
-    #BR_CS contains the Itaipu Dam.
-    #We merge the hydro keys into one, then remove unnecessary keys.
+    # BR_CS contains the Itaipu Dam.
+    # We merge the hydro keys into one, then remove unnecessary keys.
     totals['hydro'] = totals.get(u'hidraulica', 0.0) + totals.get(u'itaipu50HzBrasil', 0.0) + totals.get(u'itaipu60Hz', 0.0)
     entriesToRemove = (u'hidraulica', u'itaipu50HzBrasil', u'itaipu60Hz', u'total')
     for k in entriesToRemove:
         totals.pop(k, None)
 
-    mapped_totals = {generation_mapping.get(name, 'unknown'): val for name, val in totals.items()}
+    mapped_totals = {generation_mapping.get(name, 'unknown'): val for name, val
+                     in totals.items()}
 
     return dt, mapped_totals
 
 
-def fetch_production(country_code, session = None):
+def fetch_production(country_code, session=None):
     """
     Requests the last known production mix (in MW) of a given country
     Arguments:
@@ -141,6 +141,7 @@ def fetch_production(country_code, session = None):
 
     return datapoint
 
+
 def fetch_exchange(country_code1, country_code2, session=None):
     """Requests the last known power exchange (in MW) between two regions
     Arguments:
@@ -160,8 +161,6 @@ def fetch_exchange(country_code1, country_code2, session=None):
 
     gd = get_data()
 
-
-
     if country_code1 in countries_exchange.keys():
         country_exchange = countries_exchange[country_code1]
 
@@ -178,7 +177,7 @@ def fetch_exchange(country_code1, country_code2, session=None):
     return data
 
 
-def fetch_region_exchange(region1, region2, session = None):
+def fetch_region_exchange(region1, region2, session=None):
     """
     Requests the last known power exchange (in MW) between two Brazilian regions.
     Arguments:
@@ -213,7 +212,7 @@ def fetch_region_exchange(region1, region2, session = None):
     return data
 
 
-if __name__ ==  '__main__':
+if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production(BR-NE) ->')

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import arrow
 from bs4 import BeautifulSoup
 import datetime
@@ -6,9 +7,9 @@ import re
 import requests
 import pandas as pd
 from pytz import timezone
-import time
 
 ab_timezone = 'Canada/Mountain'
+
 
 def convert_time_str(ts):
     """Takes a time string and converts into an aware datetime object."""
@@ -18,6 +19,7 @@ def convert_time_str(ts):
     dt_aware = localtz.localize(dt_naive)
 
     return dt_aware
+
 
 def fetch_production(country_code='CA-AB', session=None):
     """Requests the last known production mix (in MW) of a given country
@@ -53,7 +55,7 @@ def fetch_production(country_code='CA-AB', session=None):
     url = 'http://ets.aeso.ca/ets_web/ip/Market/Reports/CSDReportServlet'
     response = r.get(url)
     soup = BeautifulSoup(response.content, 'html.parser')
-    findtime = soup.find('td', text = re.compile('Last Update')).get_text()
+    findtime = soup.find('td', text=re.compile('Last Update')).get_text()
     time_string = findtime.split(':', 1)[1]
     dt = convert_time_str(time_string)
 

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 import datetime
@@ -64,18 +65,18 @@ def fetch_production(country_code='CA-AB', session=None):
         'datetime': dt,
         'countryCode': country_code,
         'production': {
-            'coal': total_net_generation['COAL'],
-            'gas': total_net_generation['GAS'],
-            'hydro': total_net_generation['HYDRO'],
-            'wind': total_net_generation['WIND'],
-            'unknown': total_net_generation['OTHER']
+            'coal': float(total_net_generation['COAL']),
+            'gas': float(total_net_generation['GAS']),
+            'hydro': float(total_net_generation['HYDRO']),
+            'wind': float(total_net_generation['WIND']),
+            'unknown': float(total_net_generation['OTHER'])
         },
         'capacity': {
-            'coal': maximum_capability['COAL'],
-            'gas': maximum_capability['GAS'],
-            'hydro': maximum_capability['HYDRO'],
-            'wind': maximum_capability['WIND'],
-            'unknown': maximum_capability['OTHER']
+            'coal': float(maximum_capability['COAL']),
+            'gas': float(maximum_capability['GAS']),
+            'hydro': float(maximum_capability['HYDRO']),
+            'wind': float(maximum_capability['WIND']),
+            'unknown': float(maximum_capability['OTHER'])
         },
         'source': 'ets.aeso.ca',
     }
@@ -172,9 +173,9 @@ def isfloat(value):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
-    print 'fetch_price() ->'
-    print fetch_price()
-    print 'fetch_exchange() ->'
-    print fetch_exchange()
+    print('fetch_production() ->')
+    print(fetch_production())
+    print('fetch_price() ->')
+    print(fetch_price())
+    print('fetch_exchange() ->')
+    print(fetch_exchange())

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -54,5 +55,5 @@ def fetch_exchange(country_code1=None, country_code2=None, session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_exchange() ->'
-    print fetch_exchange()
+    print('fetch_exchange() ->')
+    print(fetch_exchange())

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes consistently with other parsers
 import arrow
 
@@ -83,9 +84,9 @@ def fetch_production(country_code='CA-NB', session=None):
     # are exchanges - positive for exports, negative for imports
     # Electricity generated in NB is then 'NB Demand' plus all the others
 
-    generated = (flows['NB Demand'] + flows['EMEC'] + flows['ISO-NE']
-                 + flows['MPS'] + flows['NOVA SCOTIA'] + flows['PEI']
-                 + flows['QUEBEC'])
+    generated = (flows['NB Demand'] + flows['EMEC'] + flows['ISO-NE'] +
+                 flows['MPS'] + flows['NOVA SCOTIA'] + flows['PEI'] +
+                 flows['QUEBEC'])
 
     data = {
         'datetime': arrow.utcnow().floor('minute').datetime,

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes consistently with other parsers
 import arrow
 

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -1,10 +1,9 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
 import requests
-
-import re
 
 
 def _get_ns_info(requests_obj):

--- a/parsers/CA_ON.py
+++ b/parsers/CA_ON.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP

--- a/parsers/CA_ON.py
+++ b/parsers/CA_ON.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -62,8 +63,9 @@ def fetch_production(country_code='CA-ON', session=None):
     for item in soup.find_all('dataset'):
         key = item.attrs['series']
         for rowIndex, row in enumerate(item.find_all('value')):
-            if not len(row.contents): continue
-            if not rowIndex in data:
+            if not len(row.contents):
+                continue
+            if rowIndex not in data:
                 data[rowIndex] = {
                     'datetime': start_datetime.replace(hours=+rowIndex).datetime,
                     'countryCode': country_code,
@@ -77,7 +79,6 @@ def fetch_production(country_code='CA-ON', session=None):
                 float(row.contents[0])
 
     return [data[k] for k in sorted(data.keys())]
-
 
 
 def fetch_price(country_code='CA-ON', session=None):
@@ -111,10 +112,12 @@ def fetch_price(country_code='CA-ON', session=None):
     # Iterate over all datasets (production types)
     for item in soup.find_all('dataset'):
         key = item.attrs['series']
-        if key != 'HOEP': continue
+        if key != 'HOEP':
+            continue
         for rowIndex, row in enumerate(item.find_all('value')):
-            if not len(row.contents): continue
-            if not rowIndex in data:
+            if not len(row.contents):
+                continue
+            if rowIndex not in data:
                 data[rowIndex] = {
                     'datetime': start_datetime.replace(hours=+rowIndex).datetime,
                     'countryCode': country_code,
@@ -151,7 +154,7 @@ def fetch_exchange(country_code1, country_code2, session=None):
     response = r.get(url)
     obj = response.json()
     exchanges = obj['intertieLineData']
-    
+
     sortedCountryCodes = '->'.join(sorted([country_code1, country_code2]))
     # Everything -> CA_ON corresponds to an import to ON
     # In the data, "net" represents an export
@@ -181,7 +184,6 @@ def fetch_exchange(country_code1, country_code2, session=None):
         'netFlow': sum(map(lambda x: float(exchanges[x]['net'].replace(',', '')), keys)) * direction,
         'source': 'gridwatch.ca'
     }
-
 
     return data
 

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes consistently with other parsers
 import arrow
 

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -1,8 +1,7 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes consistently with other parsers
 import arrow
-
-import datetime
 
 # The request library is used to fetch content through HTTP
 import requests

--- a/parsers/CA_YT.py
+++ b/parsers/CA_YT.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import arrow
 from bs4 import BeautifulSoup
 import requests

--- a/parsers/CA_YT.py
+++ b/parsers/CA_YT.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 import requests

--- a/parsers/CL_SING.py
+++ b/parsers/CL_SING.py
@@ -1,8 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-#Parser for the Chile-SING region.
-#There are plans to unify the Chilean grid.
-#https://www.engerati.com/article/chile%E2%80%99s-grid-be-unified-new-transmission-highway
+# Parser for the Chile-SING region.
+# There are plans to unify the Chilean grid.
+# https://www.engerati.com/article/chile%E2%80%99s-grid-be-unified-new-transmission-highway
 
 from __future__ import print_function
 from bs4 import BeautifulSoup
@@ -36,7 +36,8 @@ plant_map = {
              u"date": "datetime"
              }
 
-def get_data(session= None):
+
+def get_data(session=None):
     """
     Makes a GET request to the data url.  Parses the returned page to find the
     data which is contained in a javascript variable.
@@ -46,14 +47,14 @@ def get_data(session= None):
     s = session or requests.Session()
     datareq = s.get(url)
     soup = BeautifulSoup(datareq.text, 'html.parser')
-    chartdata = soup.find('script', type = "text/javascript").text
+    chartdata = soup.find('script', type="text/javascript").text
 
-    #regex that finds js var called chartData, list can be variable length.
+    # regex that finds js var called chartData, list can be variable length.
     pattern = r'chartData = \[(.*)\]'
     match = re.search(pattern, chartdata)
     rawdata = match.group(0)
 
-    #Cut down to just the list.
+    # Cut down to just the list.
     start = rawdata.index('[')
     sliced = rawdata[start:]
     loaded_data = json.loads(sliced)
@@ -85,18 +86,19 @@ def data_processer(data):
             datapoint.pop(bad, None)
 
         for key in datapoint.keys():
-            if not key in plant_map.keys():
+            if key not in plant_map.keys():
                 print('{} is missing from the CL_SING plant mapping.'.format(key))
 
-        mapped_plants = [(plant_map.get(plant, 'unknown'), val) for plant, val in datapoint.items()]
+        mapped_plants = [(plant_map.get(plant, 'unknown'), val) for plant, val
+                         in datapoint.items()]
         datapoint = defaultdict(lambda: 0.0)
 
-        #Sum values for duplicate keys.
-        for key,val in mapped_plants:
+        # Sum values for duplicate keys.
+        for key, val in mapped_plants:
             try:
                 datapoint[key] += val
             except TypeError:
-                #datetime key is a string!
+                # datetime key is a string!
                 datapoint[key] = val
 
         datapoint['datetime'] = convert_time_str(datapoint['datetime'])
@@ -105,7 +107,7 @@ def data_processer(data):
     return clean_data
 
 
-def fetch_production(country_code = 'CL-SING', session = None):
+def fetch_production(country_code='CL-SING', session=None):
     """
     Requests the last known production mix (in MW) of a given country
     Arguments:
@@ -134,7 +136,7 @@ def fetch_production(country_code = 'CL-SING', session = None):
     }
     """
 
-    gd = get_data(session = None)
+    gd = get_data(session=None)
     dp = data_processer(gd)
     production_mix_by_hour = []
     for point in dp:
@@ -153,7 +155,7 @@ def fetch_production(country_code = 'CL-SING', session = None):
     return production_mix_by_hour
 
 
-if __name__ ==  '__main__':
+if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')

--- a/parsers/CL_SING.py
+++ b/parsers/CL_SING.py
@@ -4,6 +4,7 @@
 #There are plans to unify the Chilean grid.
 #https://www.engerati.com/article/chile%E2%80%99s-grid-be-unified-new-transmission-highway
 
+from __future__ import print_function
 from bs4 import BeautifulSoup
 from collections import defaultdict
 import datetime
@@ -85,9 +86,9 @@ def data_processer(data):
 
         for key in datapoint.keys():
             if not key in plant_map.keys():
-                print '{} is missing from the CL_SING plant mapping.'.format(key)
+                print('{} is missing from the CL_SING plant mapping.'.format(key))
 
-        mapped_plants = [(plant_map.get(plant, 'unknown'), val) for plant, val in datapoint.iteritems()]
+        mapped_plants = [(plant_map.get(plant, 'unknown'), val) for plant, val in datapoint.items()]
         datapoint = defaultdict(lambda: 0.0)
 
         #Sum values for duplicate keys.

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import arrow
 import pandas as pd
 import requests
@@ -102,7 +103,7 @@ unmapped = set()
 
 def unknown_plants():
     for plant in unmapped:
-        print '{} is not mapped to generation type!'.format(plant)
+        print('{} is not mapped to generation type!'.format(plant))
 
 
 def empty_record(country_code):
@@ -137,7 +138,7 @@ def df_to_data(country_code, day, df):
     hours = 0
     for column in df:
         data.append(empty_record(country_code))
-        for index, value in df[column].iteritems():
+        for index, value in df[column].items():
             current = len(data) - 1
             source = POWER_PLANTS.get(index)
             if source == None:
@@ -226,7 +227,7 @@ def fetch_exchange(country_code1='CR', country_code2='NI', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
-    print 'fetch_exchange() ->'
-    print fetch_exchange()
+    print('fetch_production() ->')
+    print(fetch_production())
+    print('fetch_exchange() ->')
+    print(fetch_exchange())

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -1,7 +1,5 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 import pandas as pd
 import requests
@@ -101,6 +99,7 @@ POWER_PLANTS = {
 
 unmapped = set()
 
+
 def unknown_plants():
     for plant in unmapped:
         print('{} is not mapped to generation type!'.format(plant))
@@ -130,7 +129,8 @@ def empty_record(country_code):
 def df_to_data(country_code, day, df):
     df = df.dropna(axis=1, how='any')
     # Check for empty dataframe
-    if df.shape == (1,1): return []
+    if df.shape == (1, 1):
+        return []
     df = df.drop([u'Intercambio Sur', u'Intercambio Norte', u'Total'])
     df = df.iloc[:, :-1]
 
@@ -141,7 +141,7 @@ def df_to_data(country_code, day, df):
         for index, value in df[column].items():
             current = len(data) - 1
             source = POWER_PLANTS.get(index)
-            if source == None:
+            if source is None:
                 source = 'unknown'
                 unmapped.add(index)
             data[current]['datetime'] = day.replace(hours=hours).datetime

--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import arrow
 import requests
 from bs4 import BeautifulSoup
@@ -10,7 +11,7 @@ except NameError:
     xrange = range  # Python 3
 
 
-def fetch_total_and_wind_production(session = None):
+def fetch_total_and_wind_production(session=None):
     """Returns an array that contains [time, total production, wind production] like below
         ['00:00', 689.0, 18.0],
         ['00:15', 680.0, 17.0],
@@ -24,11 +25,11 @@ def fetch_total_and_wind_production(session = None):
 
     # first we ensure the column headers are what we expect, otherwise exception
     header = soup.find_all('tr')[0].find_all('th')
-    if header[0].string != 'Time' or \
-        header[1].string != 'Generation Forecast' or \
-        header[2].string != 'Actual Generation (MW)' or \
-        header[3].string != 'Total Available Generation Capacity' or \
-        header[4].string != 'Wind Farms Generation':
+    if (header[0].string != 'Time' or
+            header[1].string != 'Generation Forecast' or
+            header[2].string != 'Actual Generation (MW)' or
+            header[3].string != 'Total Available Generation Capacity' or
+            header[4].string != 'Wind Farms Generation'):
         raise Exception('Mapping for Cyprus has changed')
 
     # now we can parse the table to find all the lines that contain actual and wind values
@@ -47,7 +48,7 @@ def fetch_total_and_wind_production(session = None):
     return res
 
 
-def fetch_solar_production_estimation(session = None):
+def fetch_solar_production_estimation(session=None):
     """
     returns an array that contains [time, solar], like the following
         ['0:0', 0.0]
@@ -77,7 +78,7 @@ def fetch_solar_production_estimation(session = None):
             # ['2', '15', '00', '', '']
             for point in data_pts:
                 try:
-                    time = str(point[0])+':'+str(point[1])
+                    time = str(point[0]) + ':' + str(point[1])
                     solar = float(point[4])
                     res.append([time, solar])
                 except (TypeError, ValueError):
@@ -180,6 +181,7 @@ def fetch_production(country_code='CY', session=None):
         })
 
     return sorted(data, key=lambda point: point['datetime'])
+
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""

--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -1,7 +1,13 @@
+from __future__ import print_function
 import arrow
 import requests
 from bs4 import BeautifulSoup
 import re
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 
 def fetch_total_and_wind_production(session = None):
@@ -178,8 +184,8 @@ def fetch_production(country_code='CY', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
+    print('fetch_production() ->')
     # print fetch_production()
     res = fetch_production()
     for r in res:
-        print r
+        print(r)

--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 from collections import defaultdict
-import itertools
 from math import isnan
 import numpy as np
 from operator import itemgetter
@@ -22,9 +20,9 @@ except NameError:
     xrange = range  # Python 3
 
 
-#This parser gets hourly electricity generation data from oc.org.do for the Dominican Republic.
-#The data is in MWh but since it is updated hourly we can view it as MW.
-#Solar generation has no data available currently but multiple projects are planned/under construction.
+# This parser gets hourly electricity generation data from oc.org.do for the Dominican Republic.
+# The data is in MWh but since it is updated hourly we can view it as MW.
+# Solar generation has no data available currently but multiple projects are planned/under construction.
 
 url = 'http://184.168.74.190:81/ReportesGraficos/ReportePostdespacho.aspx'
 
@@ -35,9 +33,9 @@ total_mapping = {
                 'Total Generado': 'Generated'
                 }
 
-#Power plant types
-#http://www.sie.gob.do/images/Estadisticas/MEM/GeneracionDiariaEnero2017/
-#Reporte_diario_de_generacion_31_enero_2017_merged2.pdf
+# Power plant types
+# http://www.sie.gob.do/images/Estadisticas/MEM/GeneracionDiariaEnero2017/
+# Reporte_diario_de_generacion_31_enero_2017_merged2.pdf
 
 thermal_plants = {
                  u'AES ANDRES': 'gas',
@@ -84,7 +82,7 @@ thermal_plants = {
                  }
 
 
-def get_data(session = None):
+def get_data(session=None):
     """
     Makes a request to source url.
     Finds main table and creates a list of all table elements in unicode string format.
@@ -124,16 +122,16 @@ def chunker(big_lst):
     Returns a dictionary.
     """
 
-    chunks = [big_lst[x:x+27] for x in xrange(0, len(big_lst), 27)]
+    chunks = [big_lst[x:x + 27] for x in xrange(0, len(big_lst), 27)]
 
-    #Remove the list if it contains no data.
+    # Remove the list if it contains no data.
     for chunk in chunks:
-        if any(chunk) == True:
+        if any(chunk):
             continue
         else:
             chunks.remove(chunk)
 
-    chunked_list = {words[0]:words[1:] for words in chunks}
+    chunked_list = {words[0]: words[1:] for words in chunks}
 
     return chunked_list
 
@@ -148,17 +146,17 @@ def data_formatter(data):
     find_totals_index = data.index(u'Total T\xe9rmico')
     find_totals_end = data.index(u'Total Programado')
 
-    ufthermal = data[find_thermal_index+3:find_totals_index-59]
+    ufthermal = data[find_thermal_index + 3:find_totals_index - 59]
     total_data = data[find_totals_index:find_totals_end]
 
-    #Remove all company names.
+    # Remove all company names.
     for val in ufthermal:
         if ':' in val:
             i = ufthermal.index(val)
-            del ufthermal[i:i+3]
+            del ufthermal[i:i + 3]
 
     formatted_thermal = chunker([floater(item) for item in ufthermal])
-    mapped_totals = [total_mapping.get(x,x) for x in total_data]
+    mapped_totals = [total_mapping.get(x, x) for x in total_data]
     formatted_totals = chunker([floater(item) for item in mapped_totals])
 
     return {'totals': formatted_totals, 'thermal': formatted_thermal}
@@ -170,12 +168,12 @@ def data_parser(formatted_data):
     Returns a DataFrame.
     """
 
-    hours = list(range(1,24)) + [0] + [25, 26]
-    dft = pd.DataFrame(formatted_data, index = hours)
+    hours = list(range(1, 24)) + [0] + [25, 26]
+    dft = pd.DataFrame(formatted_data, index=hours)
 
-    dft = dft.drop(dft.index[[-1,-2]])
+    dft = dft.drop(dft.index[[-1, -2]])
     dft = dft.replace(u'', np.nan)
-    dft = dft.dropna(how = 'all')
+    dft = dft.dropna(how='all')
 
     return dft
 
@@ -190,10 +188,10 @@ def thermal_production(df):
     therms = []
     unmapped = set()
     for hour in df.index.values:
-        dt=hour
+        dt = hour
         currentt = df.loc[[hour]]
 
-        #Create current plant output.
+        # Create current plant output.
         tp = {}
         for item in list(df):
             v = currentt.iloc[0][item]
@@ -209,8 +207,8 @@ def thermal_production(df):
 
         thermalDict = defaultdict(lambda: 0.0)
 
-        #Sum values for duplicate keys.
-        for key,val in mapped_plants:
+        # Sum values for duplicate keys.
+        for key, val in mapped_plants:
             thermalDict[key] += val
 
         thermalDict['datetime'] = dt
@@ -230,16 +228,17 @@ def total_production(df):
     """
 
     vals = []
-    #The Dominican Republic does not observe daylight savings time.
+    # The Dominican Republic does not observe daylight savings time.
     for hour in df.index.values:
-        dt=hour
+        dt = hour
         current = df.loc[[hour]]
         hydro = current.iloc[0]['Hydro']
         wind = current.iloc[0]['Wind']
-        if wind > -10: wind = max(wind, 0)
+        if wind > -10:
+            wind = max(wind, 0)
 
-        #Wind and hydro totals do not always update exactly on the new hour.
-        #In this case we set them to None because they are unknown rather than zero.
+        # Wind and hydro totals do not always update exactly on the new hour.
+        # In this case we set them to None because they are unknown rather than zero.
         if isnan(wind):
             wind = None
         if isnan(hydro):
@@ -277,7 +276,7 @@ def merge_production(thermal, total):
     return final
 
 
-def fetch_production(country_code = 'DO', session = None):
+def fetch_production(country_code='DO', session=None):
     """
     Requests the last known production mix (in MW) of a given country
     Arguments:
@@ -306,7 +305,7 @@ def fetch_production(country_code = 'DO', session = None):
     }
     """
 
-    dat = data_formatter(get_data(session = None))
+    dat = data_formatter(get_data(session=None))
     tot = data_parser(dat['totals'])
     th = data_parser(dat['thermal'])
     thermal = thermal_production(th)
@@ -340,7 +339,7 @@ def fetch_production(country_code = 'DO', session = None):
     return production_mix_by_hour
 
 
-if __name__ ==  '__main__':
+if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')

--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 from collections import defaultdict
@@ -9,6 +10,16 @@ import numpy as np
 from operator import itemgetter
 import pandas as pd
 import requests
+
+try:
+    unicode         # Python 2
+except NameError:
+    unicode = str   # Python 3
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 
 #This parser gets hourly electricity generation data from oc.org.do for the Dominican Republic.
@@ -159,7 +170,7 @@ def data_parser(formatted_data):
     Returns a DataFrame.
     """
 
-    hours = range(1,24) + [0] + [25, 26]
+    hours = list(range(1,24)) + [0] + [25, 26]
     dft = pd.DataFrame(formatted_data, index = hours)
 
     dft = dft.drop(dft.index[[-1,-2]])
@@ -194,7 +205,7 @@ def thermal_production(df):
             if plant not in thermal_plants.keys():
                 unmapped.add(plant)
 
-        mapped_plants = [(thermal_plants.get(plant, 'unknown'), val) for plant, val in current_plants.iteritems()]
+        mapped_plants = [(thermal_plants.get(plant, 'unknown'), val) for plant, val in current_plants.items()]
 
         thermalDict = defaultdict(lambda: 0.0)
 
@@ -207,7 +218,7 @@ def thermal_production(df):
         therms.append(thermalDict)
 
     for plant in unmapped:
-        print '{} is missing from the DO plant mapping!'.format(plant)
+        print('{} is missing from the DO plant mapping!'.format(plant))
 
     return therms
 

--- a/parsers/ENTE.py
+++ b/parsers/ENTE.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-#This parser gets all real time interconnection flows from the
-#Central American Electrical Interconnection System (SIEPAC).
+# This parser gets all real time interconnection flows from the
+# Central American Electrical Interconnection System (SIEPAC).
 
-from __future__ import print_function
 import arrow
-import numpy as np
 import pandas as pd
 
 url = 'http://www.enteoperador.org/newsite/flash/data.csv'
@@ -28,15 +26,13 @@ def connections(df):
     Returns a dictionary.
     """
 
-    interconnections = {
-                        'GT->MX': df.iloc[0]['MXGU'],
+    interconnections = {'GT->MX': df.iloc[0]['MXGU'],
                         'GT->SV': df.iloc[0]['GUES'],
                         'GT->HN': df.iloc[0]['GUHO'],
                         'HN->SV': df.iloc[0]['ESHO'],
                         'HN->NI': df.iloc[0]['HONI'],
                         'CR->NI': df.iloc[0]['NICR'],
-                        'CR->PA': df.iloc[0]['CRPA']
-                        }
+                        'CR->PA': df.iloc[0]['CRPA']}
 
     return interconnections
 
@@ -66,14 +62,14 @@ def flow_logic(net_production, interconnections):
     Returns a dictionary.
     """
 
-    #Each country is modeled as a node with flows going either in or out of it.
-    #Importing is given a negative flow while exporting is positive.
+    # Each country is modeled as a node with flows going either in or out of it.
+    # Importing is given a negative flow while exporting is positive.
 
     PA = {'CR': 0}
     CR = {'PA': 0, 'NI': 0}
     NI = {'CR': 0, 'HN': 0}
     HN = {'GT': 0, 'SV': 0, 'NI': 0}
-    SV = {'GT': 0, 'HN': 0}
+    SV = {'GT': 0, 'HN': 0}  # TODO: SV is assigned to but never used
     GT = {'MX': 0, 'HN': 0, 'SV': 0}
 
     def plusminus(value):
@@ -98,52 +94,50 @@ def flow_logic(net_production, interconnections):
         -1 -> 1
         """
 
-        newvalue = (-1)*value
+        newvalue = (-1) * value
 
         return newvalue
 
-    flows = {
-             'HN->NI': 0.0,
+    flows = {'HN->NI': 0.0,
              'CR->NI': 0.0,
              'CR->PA': 0.0,
              'GT->HN': 0.0,
              'GT->MX': 0.0,
              'GT->SV': 0.0,
-             'HN->SV': 0.0
-             }
+             'HN->SV': 0.0}
 
-    #First we determine whether Mexico is importing or exporting using totals for the SIEPAC system.
+    # First we determine whether Mexico is importing or exporting using totals for the SIEPAC system.
 
     if net_production['MX'] < 0:
-        #exporting
+        # exporting
         GT['MX'] = -1
     else:
         GT['MX'] = 1
 
-    #We then find the direction of the PA by exploiting the fact that it only has one interconnection.
+    # We then find the direction of the PA by exploiting the fact that it only has one interconnection.
 
     if net_production['PA'] > 0:
-        #PA can only export to CR
+        # PA can only export to CR
         PA['CR'] = 1
         CR['PA'] = -1
     else:
-        #PA importing from CR
+        # PA importing from CR
         PA['CR'] = -1
         CR['PA'] = 1
 
-    #Next we can find CR and NI flows using their net productions and process of elimination.
+    # Next we can find CR and NI flows using their net productions and process of elimination.
 
-    PAN = interconnections['CR->PA']*CR['PA']
+    PAN = interconnections['CR->PA'] * CR['PA']
 
-    CR['NI'] = plusminus((net_production['CR']-PAN)/interconnections['CR->NI'])
+    CR['NI'] = plusminus((net_production['CR'] - PAN) / interconnections['CR->NI'])
     NI['CR'] = flipsign(CR['NI'])
-    NIC = interconnections['CR->NI']*NI['CR']
+    NIC = interconnections['CR->NI'] * NI['CR']
 
-    NI['HN'] = plusminus((net_production['NI']-NIC)/interconnections['HN->NI'])
+    NI['HN'] = plusminus((net_production['NI'] - NIC) / interconnections['HN->NI'])
     HN['NI'] = flipsign(NI['HN'])
 
-    #Now we use 3 simultaneous equations to find the remaining flows.  We can use the fact that
-    #several flows are already known to our advantage.
+    # Now we use 3 simultaneous equations to find the remaining flows.  We can use the fact that
+    # several flows are already known to our advantage.
 
     # a = interconnections['GT->SV']
     # b = interconnections['HN->SV']
@@ -165,14 +159,14 @@ def flow_logic(net_production, interconnections):
     # GT['HN'] = plusminus(solution[2])
     # HN['GT'] = flipsign(GT['HN'])
 
-    #Flows commented out are disabled until the maths behind determining their direction can be proved satisfactorily.
+    # Flows commented out are disabled until the maths behind determining their direction can be proved satisfactorily.
     flows['HN->NI'] = HN['NI']
     flows['CR->NI'] = CR['NI']
     flows['CR->PA'] = CR['PA']
-    #flows['GT->HN'] = GT['HN']
+    # flows['GT->HN'] = GT['HN']
     flows['GT->MX'] = GT['MX']
-    #flows['GT->SV'] = GT['SV']
-    #flows['HN->SV'] = SV['HN']
+    # flows['GT->SV'] = GT['SV']
+    # flows['HN->SV'] = SV['HN']
 
     return flows
 
@@ -183,7 +177,7 @@ def net_flow(interconnections, flows):
     Returns a dictionary.
     """
 
-    netflow = {k: interconnections[k]*flows[k] for k in interconnections}
+    netflow = {k: interconnections[k] * flows[k] for k in interconnections}
 
     return netflow
 
@@ -216,14 +210,14 @@ def fetch_exchange(country_code1, country_code2, session=None):
     else:
         raise NotImplementedError('This exchange is not implemented.')
 
-    exchange.update(sortedCountryCodes = zones,
-                    datetime = dt.datetime,
-                    source = 'enteoperador.org')
+    exchange.update(sortedCountryCodes=zones,
+                    datetime=dt.datetime,
+                    source='enteoperador.org')
 
     return exchange
 
 
-if __name__ ==  '__main__':
+if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_exchange(CR, PA) ->')

--- a/parsers/ENTE.py
+++ b/parsers/ENTE.py
@@ -3,6 +3,7 @@
 #This parser gets all real time interconnection flows from the
 #Central American Electrical Interconnection System (SIEPAC).
 
+from __future__ import print_function
 import arrow
 import numpy as np
 import pandas as pd
@@ -226,10 +227,10 @@ if __name__ ==  '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_exchange(CR, PA) ->')
-    print fetch_exchange('CR', 'PA')
+    print(fetch_exchange('CR', 'PA'))
     print('fetch_exchange(CR, NI) ->')
-    print fetch_exchange('CR', 'NI')
+    print(fetch_exchange('CR', 'NI'))
     print('fetch_exchange(HN, NI) ->')
-    print fetch_exchange('HN', 'NI')
+    print(fetch_exchange('HN', 'NI'))
     print('fetch_exchange(GT, MX) ->')
-    print fetch_exchange('GT', 'MX')
+    print(fetch_exchange('GT', 'MX'))

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -1,7 +1,11 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 from bs4 import BeautifulSoup
 from collections import defaultdict
-import arrow, os, re, requests
+import arrow
+import os
+import re
+import requests
 
 ENTSOE_ENDPOINT = 'https://transparency.entsoe.eu/api'
 ENTSOE_PARAMETER_DESC = {
@@ -88,8 +92,10 @@ ENTSOE_EXCHANGE_DOMAIN_OVERRIDE = {
     'PL->UA': [ENTSOE_DOMAIN_MAPPINGS['PL'], '10Y1001A1001A869']
 }
 
+
 class QueryError(Exception):
     """Raised when a query to ENTSOE returns no matching data."""
+
 
 def check_response(response, function_name):
     """
@@ -101,17 +107,21 @@ def check_response(response, function_name):
     text = soup.find_all('text')
     if len(text):
         error_text = soup.find_all('text')[0].prettify()
-        if 'No matching data found' in error_text:return
+        if 'No matching data found' in error_text:
+            return
         raise QueryError('{0} failed in ENTSOE.py. Reason: {1}'.format(function_name, error_text))
 
+
 def query_ENTSOE(session, params, now=None, span=[-24, 24]):
-    if now is None: now = arrow.utcnow()
+    if now is None:
+        now = arrow.utcnow()
     params['periodStart'] = now.replace(hours=span[0]).format('YYYYMMDDHH00')
     params['periodEnd'] = now.replace(hours=+span[1]).format('YYYYMMDDHH00')
-    if not 'ENTSOE_TOKEN' in os.environ:
+    if 'ENTSOE_TOKEN' not in os.environ:
         raise Exception('No ENTSOE_TOKEN found! Please add it into secrets.env!')
     params['securityToken'] = os.environ['ENTSOE_TOKEN']
     return session.get(ENTSOE_ENDPOINT, params=params)
+
 
 def query_consumption(domain, session, now=None):
     params = {
@@ -120,22 +130,26 @@ def query_consumption(domain, session, now=None):
         'outBiddingZone_Domain': domain,
     }
     response = query_ENTSOE(session, params, now)
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         check_response(response, query_consumption.__name__)
+
 
 def query_production(psr_type, in_domain, session, now=None):
     params = {
         'psrType': psr_type,
         'documentType': 'A75',
-        'processType': 'A16', # Realised
+        'processType': 'A16',  # Realised
         'in_Domain': in_domain,
     }
     response = query_ENTSOE(session, params, now)
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         print('Query failed for psr %s' % psr_type)
         check_response(response, query_production.__name__)
+
 
 def query_exchange(in_domain, out_domain, session, now=None):
     params = {
@@ -144,20 +158,24 @@ def query_exchange(in_domain, out_domain, session, now=None):
         'out_Domain': out_domain,
     }
     response = query_ENTSOE(session, params, now)
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         check_response(response, query_exchange.__name__)
 
+
 def query_exchange_forecast(in_domain, out_domain, session, now=None):
     params = {
-        'documentType': 'A09', # Finalised schedule
+        'documentType': 'A09',  # Finalised schedule
         'in_Domain': in_domain,
         'out_Domain': out_domain,
     }
     response = query_ENTSOE(session, params, now, span=[-24, 48])
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         check_response(response, query_exchange_forecast.__name__)
+
 
 def query_price(domain, session, now=None):
     params = {
@@ -166,32 +184,38 @@ def query_price(domain, session, now=None):
         'out_Domain': domain,
     }
     response = query_ENTSOE(session, params, now)
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         check_response(response, query_price.__name__)
+
 
 def query_generation_forecast(in_domain, session, now=None):
     # Note: this does not give a breakdown of the production
     params = {
-        'documentType': 'A71', # Generation Forecast
-        'processType': 'A01', # Realised
+        'documentType': 'A71',  # Generation Forecast
+        'processType': 'A01',  # Realised
         'in_Domain': in_domain,
     }
     response = query_ENTSOE(session, params, now, span=[-24, 48])
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         check_response(response, query_generation_forecast.__name__)
 
+
 def query_consumption_forecast(in_domain, session, now=None):
     params = {
-        'documentType': 'A65', # Load Forecast
+        'documentType': 'A65',  # Load Forecast
         'processType': 'A01',
         'outBiddingZone_Domain': in_domain,
     }
     response = query_ENTSOE(session, params, now, span=[-24, 48])
-    if response.ok: return response.text
+    if response.ok:
+        return response.text
     else:
         check_response(response, query_generation_forecast.__name__)
+
 
 def datetime_from_position(start, position, resolution):
     m = re.search('PT(\d+)([M])', resolution)
@@ -202,8 +226,10 @@ def datetime_from_position(start, position, resolution):
             return start.replace(minutes=position * digits)
     raise NotImplementedError('Could not recognise resolution %s' % resolution)
 
+
 def parse_consumption(xml_text):
-    if not xml_text: return None
+    if not xml_text:
+        return None
     soup = BeautifulSoup(xml_text, 'html.parser')
     # Get all points
     quantities = []
@@ -217,8 +243,10 @@ def parse_consumption(xml_text):
             datetimes.append(datetime_from_position(datetime_start, position, resolution))
     return quantities, datetimes
 
+
 def parse_production(xml_text):
-    if not xml_text: return None
+    if not xml_text:
+        return None
     soup = BeautifulSoup(xml_text, 'html.parser')
     # Get all points
     productions = []
@@ -237,15 +265,17 @@ def parse_production(xml_text):
                     productions[i] += quantity
                 else:
                     productions[i] -= quantity
-            except ValueError: # Not in list
+            except ValueError:  # Not in list
                 datetimes.append(datetime)
                 productions.append(quantity if is_production else -1 * quantity)
     return productions, datetimes
 
+
 def parse_exchange(xml_text, is_import, quantities=None, datetimes=None):
-    if not xml_text: return None
-    if not quantities: quantities = []
-    if not datetimes: datetimes = []
+    if not xml_text:
+        return None
+    quantities = quantities or []
+    datetimes = datetimes or []
     soup = BeautifulSoup(xml_text, 'html.parser')
     # Get all points
     for timeseries in soup.find_all('timeseries'):
@@ -253,20 +283,23 @@ def parse_exchange(xml_text, is_import, quantities=None, datetimes=None):
         datetime_start = arrow.get(timeseries.find_all('start')[0].contents[0])
         for entry in timeseries.find_all('point'):
             quantity = float(entry.find_all('quantity')[0].contents[0])
-            if not is_import: quantity *= -1
+            if not is_import:
+                quantity *= -1
             position = int(entry.find_all('position')[0].contents[0])
             datetime = datetime_from_position(datetime_start, position, resolution)
             # Find out whether or not we should update the net production
             try:
                 i = datetimes.index(datetime)
                 quantities[i] += quantity
-            except ValueError: # Not in list
+            except ValueError:  # Not in list
                 quantities.append(quantity)
                 datetimes.append(datetime)
     return quantities, datetimes
 
+
 def parse_price(xml_text):
-    if not xml_text: return None
+    if not xml_text:
+        return None
     soup = BeautifulSoup(xml_text, 'html.parser')
     # Get all points
     prices = []
@@ -278,14 +311,16 @@ def parse_price(xml_text):
         datetime_start = arrow.get(timeseries.find_all('start')[0].contents[0])
         for entry in timeseries.find_all('point'):
             position = int(entry.find_all('position')[0].contents[0])
-            datetime=datetime_from_position(datetime_start, position, resolution)
+            datetime = datetime_from_position(datetime_start, position, resolution)
             prices.append(float(entry.find_all('price.amount')[0].contents[0]))
             datetimes.append(datetime)
             currencies.append(currency)
     return prices, currencies, datetimes
 
+
 def parse_generation_forecast(xml_text):
-    if not xml_text: return None
+    if not xml_text:
+        return None
     soup = BeautifulSoup(xml_text, 'html.parser')
     # Get all points
     values = []
@@ -296,13 +331,15 @@ def parse_generation_forecast(xml_text):
         for entry in timeseries.find_all('point'):
             position = int(entry.find_all('position')[0].contents[0])
             value = float(entry.find_all('quantity')[0].contents[0])
-            datetime=datetime_from_position(datetime_start, position, resolution)
+            datetime = datetime_from_position(datetime_start, position, resolution)
             values.append(value)
             datetimes.append(datetime)
     return values, datetimes
 
+
 def parse_consumption_forecast(xml_text):
-    if not xml_text: return None
+    if not xml_text:
+        return None
     soup = BeautifulSoup(xml_text, 'html.parser')
     # Get all points
     values = []
@@ -313,10 +350,11 @@ def parse_consumption_forecast(xml_text):
         for entry in timeseries.find_all('point'):
             position = int(entry.find_all('position')[0].contents[0])
             value = float(entry.find_all('quantity')[0].contents[0])
-            datetime=datetime_from_position(datetime_start, position, resolution)
+            datetime = datetime_from_position(datetime_start, position, resolution)
             values.append(value)
             datetimes.append(datetime)
     return values, datetimes
+
 
 def validate_production(datapoint):
     codes = ('GB', 'GR', 'PT')
@@ -342,7 +380,9 @@ def validate_production(datapoint):
         return p.get('coal', None) is not None and \
                p.get('gas', None) is not None and \
                p.get('nuclear', None) is not None
-    else: return True
+    else:
+        return True
+
 
 def get_biomass(values):
     if 'Biomass' in values or 'Fossil Peat' in values or 'Waste' in values:
@@ -350,49 +390,59 @@ def get_biomass(values):
             values.get('Fossil Peat', 0) + \
             values.get('Waste', 0)
 
+
 def get_coal(values):
     if 'Fossil Brown coal/Lignite' in values or 'Fossil Hard coal' in values:
         return values.get('Fossil Brown coal/Lignite', 0) + \
             values.get('Fossil Hard coal', 0)
+
 
 def get_gas(values):
     if 'Fossil Coal-derived gas' in values or 'Fossil Gas' in values:
         return values.get('Fossil Coal-derived gas', 0) + \
             values.get('Fossil Gas', 0)
 
+
 def get_hydro(values):
-    if 'Hydro Run-of-river and poundage' in values \
-        or 'Hydro Water Reservoir' in values:
+    if ('Hydro Run-of-river and poundage' in values or
+            'Hydro Water Reservoir' in values):
         return values.get('Hydro Run-of-river and poundage', 0) + \
             values.get('Hydro Water Reservoir', 0)
+
 
 def get_hydro_storage(storage_values):
     if 'Hydro Pumped Storage' in storage_values:
         return -1 * storage_values.get('Hydro Pumped Storage', 0)
+
 
 def get_oil(values):
     if 'Fossil Oil' in values or 'Fossil Oil shale' in values:
         value = values.get('Fossil Oil', 0) + values.get('Fossil Oil shale', 0)
         return value if value != -1.0 else None
 
+
 def get_wind(values):
     if 'Wind Onshore' in values or 'Wind Offshore' in values:
         return values.get('Wind Onshore', 0) + values.get('Wind Offshore', 0)
 
+
 def get_geothermal(values):
     if 'Geothermal' in values:
-        return values.get('Geothermal', 0);
+        return values.get('Geothermal', 0)
+
 
 def get_unknown(values):
-    if 'Marine' in values \
-        or 'Other renewable' in values \
-        or 'Other' in values:
-        return values.get('Marine', 0) + \
-            values.get('Other renewable', 0) + \
-            values.get('Other', 0)
+    if ('Marine' in values or
+            'Other renewable' in values or
+            'Other' in values):
+        return (values.get('Marine', 0) +
+                values.get('Other renewable', 0) +
+                values.get('Other', 0))
+
 
 def fetch_consumption(country_code, session=None):
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     domain = ENTSOE_DOMAIN_MAPPINGS[country_code]
     # Grab consumption
     parsed = parse_consumption(query_consumption(domain, session))
@@ -407,8 +457,10 @@ def fetch_consumption(country_code, session=None):
 
         return data
 
+
 def fetch_production(country_code, session=None, now=None):
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     domain = ENTSOE_DOMAIN_MAPPINGS[country_code]
     # Create a double hashmap with keys (datetime, parameter)
     production_hashmap = defaultdict(lambda: {})
@@ -420,11 +472,11 @@ def fetch_production(country_code, session=None, now=None):
             for i in range(len(datetimes)):
                 production_hashmap[datetimes[i]][k] = productions[i]
 
-
     # Remove all dates in the future
     production_dates = sorted(set(production_hashmap.keys()), reverse=True)
     production_dates = list(filter(lambda x: x <= arrow.now(), production_dates))
-    if not len(production_dates): return None
+    if not len(production_dates):
+        return None
     # Only take fully observed elements
     max_counts = max(map(lambda d: len(production_hashmap[d].keys()),
         production_dates))
@@ -459,8 +511,10 @@ def fetch_production(country_code, session=None, now=None):
 
     return list(filter(validate_production, data))
 
+
 def fetch_exchange(country_code1, country_code2, session=None, now=None):
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     sorted_country_codes = sorted([country_code1, country_code2])
     key = '->'.join(sorted_country_codes)
     if key in ENTSOE_EXCHANGE_DOMAIN_OVERRIDE:
@@ -488,7 +542,8 @@ def fetch_exchange(country_code1, country_code2, session=None, now=None):
     # Remove all dates in the future
     exchange_dates = sorted(set(exchange_hashmap.keys()), reverse=True)
     exchange_dates = list(filter(lambda x: x <= arrow.now(), exchange_dates))
-    if not len(exchange_dates): return None
+    if not len(exchange_dates):
+        return None
     data = []
     for exchange_date in exchange_dates:
         netFlow = exchange_hashmap[exchange_date]
@@ -500,8 +555,10 @@ def fetch_exchange(country_code1, country_code2, session=None, now=None):
         })
     return data
 
+
 def fetch_exchange_forecast(country_code1, country_code2, session=None, now=None):
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     domain1 = ENTSOE_DOMAIN_MAPPINGS[country_code1]
     domain2 = ENTSOE_DOMAIN_MAPPINGS[country_code2]
     # Create a hashmap with key (datetime)
@@ -524,7 +581,8 @@ def fetch_exchange_forecast(country_code1, country_code2, session=None, now=None
     # Remove all dates in the future
     sorted_country_codes = sorted([country_code1, country_code2])
     exchange_dates = list(sorted(set(exchange_hashmap.keys()), reverse=True))
-    if not len(exchange_dates): return None
+    if not len(exchange_dates):
+        return None
     data = []
     for exchange_date in exchange_dates:
         netFlow = exchange_hashmap[exchange_date]
@@ -536,9 +594,11 @@ def fetch_exchange_forecast(country_code1, country_code2, session=None, now=None
         })
     return data
 
+
 def fetch_price(country_code, session=None, now=None):
     # Note: This is day-ahead prices
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     domain = ENTSOE_DOMAIN_MAPPINGS[country_code]
     # Grab consumption
     parsed = parse_price(query_price(domain, session, now))
@@ -556,8 +616,10 @@ def fetch_price(country_code, session=None, now=None):
 
         return data
 
+
 def fetch_generation_forecast(country_code, session=None, now=None):
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     domain = ENTSOE_DOMAIN_MAPPINGS[country_code]
     # Grab consumption
     parsed = parse_generation_forecast(query_generation_forecast(domain, session, now))
@@ -576,7 +638,8 @@ def fetch_generation_forecast(country_code, session=None, now=None):
 
 
 def fetch_consumption_forecast(country_code, session=None, now=None):
-    if not session: session = requests.session()
+    if not session:
+        session = requests.session()
     domain = ENTSOE_DOMAIN_MAPPINGS[country_code]
     # Grab consumption
     parsed = parse_consumption_forecast(query_consumption_forecast(domain, session, now))

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from bs4 import BeautifulSoup
 from collections import defaultdict
 import arrow, os, re, requests
@@ -25,7 +26,7 @@ ENTSOE_PARAMETER_DESC = {
     'B19': 'Wind Onshore',
     'B20': 'Other',
 }
-ENTSOE_PARAMETER_BY_DESC = {v: k for k, v in ENTSOE_PARAMETER_DESC.iteritems()}
+ENTSOE_PARAMETER_BY_DESC = {v: k for k, v in ENTSOE_PARAMETER_DESC.items()}
 # Define all ENTSOE country_code <-> domain mapping
 ENTSOE_DOMAIN_MAPPINGS = {
     'AL': '10YAL-KESH-----5',
@@ -133,7 +134,7 @@ def query_production(psr_type, in_domain, session, now=None):
     response = query_ENTSOE(session, params, now)
     if response.ok: return response.text
     else:
-        print 'Query failed for psr %s' % psr_type
+        print('Query failed for psr %s' % psr_type)
         check_response(response, query_production.__name__)
 
 def query_exchange(in_domain, out_domain, session, now=None):
@@ -422,10 +423,10 @@ def fetch_production(country_code, session=None, now=None):
 
     # Remove all dates in the future
     production_dates = sorted(set(production_hashmap.keys()), reverse=True)
-    production_dates = filter(lambda x: x <= arrow.now(), production_dates)
+    production_dates = list(filter(lambda x: x <= arrow.now(), production_dates))
     if not len(production_dates): return None
     # Only take fully observed elements
-    max_counts = max(map(lambda date: len(production_hashmap[date].keys()),
+    max_counts = max(map(lambda d: len(production_hashmap[d].keys()),
         production_dates))
     production_dates = filter(lambda d: len(production_hashmap[d].keys()) == max_counts,
         production_dates)
@@ -433,7 +434,7 @@ def fetch_production(country_code, session=None, now=None):
     data = []
     for production_date in production_dates:
 
-        production_values = {ENTSOE_PARAMETER_DESC[k]: v for k, v in production_hashmap[production_date].iteritems()}
+        production_values = {ENTSOE_PARAMETER_DESC[k]: v for k, v in production_hashmap[production_date].items()}
 
         data.append({
             'countryCode': country_code,
@@ -456,7 +457,7 @@ def fetch_production(country_code, session=None, now=None):
             'source': 'entsoe.eu'
         })
 
-    return filter(validate_production, data)
+    return list(filter(validate_production, data))
 
 def fetch_exchange(country_code1, country_code2, session=None, now=None):
     if not session: session = requests.session()
@@ -486,7 +487,7 @@ def fetch_exchange(country_code1, country_code2, session=None, now=None):
 
     # Remove all dates in the future
     exchange_dates = sorted(set(exchange_hashmap.keys()), reverse=True)
-    exchange_dates = filter(lambda x: x <= arrow.now(), exchange_dates)
+    exchange_dates = list(filter(lambda x: x <= arrow.now(), exchange_dates))
     if not len(exchange_dates): return None
     data = []
     for exchange_date in exchange_dates:
@@ -522,7 +523,7 @@ def fetch_exchange_forecast(country_code1, country_code2, session=None, now=None
 
     # Remove all dates in the future
     sorted_country_codes = sorted([country_code1, country_code2])
-    exchange_dates = sorted(set(exchange_hashmap.keys()), reverse=True)
+    exchange_dates = list(sorted(set(exchange_hashmap.keys()), reverse=True))
     if not len(exchange_dates): return None
     data = []
     for exchange_date in exchange_dates:

--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 
 from os import environ
 from urllib.parse import urlencode

--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -1,32 +1,36 @@
+from __future__ import print_function
+
+from os import environ
+from urllib.parse import urlencode
+
 # The arrow library is used to handle datetimes
 import arrow
-import urllib
 # The request library is used to fetch content through HTTP
 import requests
-from os import environ
+
 from parsers.lib.exceptions import ParserException
 
 
 def fetch_exchange(country_code1='ES', country_code2='MA', session=None, token=None):
 
-    ## Get ESIOS token
+    # Get ESIOS token
     token = environ.get('ESIOS_TOKEN', token)
     if not token:
         raise ParserException("ESIOS", "Require access token")
 
     ses = session or requests.Session()
 
-    ## Request headers
+    # Request headers
     headers = {'Content-Type': 'application/json',
                'Accept': 'application/json; application/vnd.esios-api-v2+json',
                'Authorization': 'Token token="{0}"'.format(token)}
 
-    ## Request query url
+    # Request query url
     utc = arrow.utcnow()
     start_date = utc.shift(hours=-24).floor('hour').isoformat()
     end_date = utc.ceil('hour').isoformat()
     dates = {'start_date': start_date, 'end_date': end_date}
-    query = urllib.urlencode(dates)
+    query = urlencode(dates)
     url = 'https://api.esios.ree.es/indicators/10209?{0}'.format(query)
 
     response = ses.get(url, headers=headers)
@@ -61,4 +65,4 @@ def fetch_exchange(country_code1='ES', country_code2='MA', session=None, token=N
 
 if __name__ == '__main__':
     session = requests.Session()
-    print fetch_exchange('ES', 'MA', session)
+    print(fetch_exchange('ES', 'MA', session))

--- a/parsers/ES_CN.py
+++ b/parsers/ES_CN.py
@@ -2,7 +2,8 @@
 from arrow import get
 # The request library is used to fetch content through HTTP
 from requests import Session
-from reescraper import ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura, LaPalma, Tenerife
+from reescraper import (ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura,
+                        LaPalma, Tenerife)
 from parsers.lib.exceptions import ParserException
 
 
@@ -13,7 +14,7 @@ def fetch_islands_data(country_code, session):
     if not el_hierro_data:
         raise ParserException(country_code, "ElHierro not response")
     else:
-        data.update({'el_hierro':  el_hierro_data})
+        data.update({'el_hierro': el_hierro_data})
 
     gran_canaria_data = GranCanaria(session).get_all()
     if not gran_canaria_data:
@@ -61,7 +62,7 @@ def fetch_consumption(country_code='ES-CN', session=None):
         consumption = response.demand
         consumption_data.update({consumption_datetime: consumption})
 
-    for island, island_data in islands_data.iteritems():
+    for island, island_data in islands_data.items():
         if not island == 'el_hierro':
             for response in island_data:
                 consumption_datetime = get(response.timestamp).datetime
@@ -72,7 +73,7 @@ def fetch_consumption(country_code='ES-CN', session=None):
 
     data = []
 
-    for datetime, demand in consumption_data.iteritems():
+    for datetime, demand in consumption_data.items():
         response_data = {
             'countryCode': country_code,
             'datetime': datetime,
@@ -106,7 +107,7 @@ def fetch_production(country_code='ES-CN', session=None):
             }
             production_data.update({production_datetime: production})
 
-    for island, island_data in islands_data.iteritems():
+    for island, island_data in islands_data.items():
         if not island == 'el_hierro':
             for response in island_data:
                 production_datetime = get(response.timestamp).datetime
@@ -127,7 +128,7 @@ def fetch_production(country_code='ES-CN', session=None):
 
     data = []
 
-    for datetime, production in production_data.iteritems():
+    for datetime, production in production_data.items():
         response_data = {
             'countryCode': country_code,
             'datetime': datetime,
@@ -156,5 +157,5 @@ def fetch_production(country_code='ES-CN', session=None):
 
 if __name__ == '__main__':
     session = Session
-    print fetch_consumption('ES-CN', session)
-    print fetch_production('ES-CN', session)
+    print(fetch_consumption('ES-CN', session))
+    print(fetch_production('ES-CN', session))

--- a/parsers/ES_CN.py
+++ b/parsers/ES_CN.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 from arrow import get
 # The request library is used to fetch content through HTTP

--- a/parsers/ES_IB.py
+++ b/parsers/ES_IB.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 from arrow import get
 # The request library is used to fetch content through HTTP

--- a/parsers/ES_IB.py
+++ b/parsers/ES_IB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 from arrow import get
 # The request library is used to fetch content through HTTP
@@ -93,6 +94,6 @@ def fetch_exchange(country_code1='ES', country_code2='ES-IB', session=None):
 
 if __name__ == '__main__':
     session = Session
-    print fetch_consumption('ES-IB', session)
-    print fetch_production('ES-IB', session)
-    print fetch_exchange('ES', 'ES-IB', session)
+    print(fetch_consumption('ES-IB', session))
+    print(fetch_production('ES-IB', session))
+    print(fetch_exchange('ES', 'ES-IB', session))

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -1,7 +1,5 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 import requests
 import xml.etree.ElementTree as ET
@@ -12,19 +10,25 @@ MAP_GENERATION = {
     'Diesel': 'oil',
     'Vind': 'wind'
 }
+
+
 def getDataKey(tag):
     return MAP_GENERATION.get(tag, None)
 
+
 def validate_datapoint(d):
-    if d['production'].get('oil', None) is None: return None
-    else: return d
+    if d['production'].get('oil', None) is None:
+        return None
+    else:
+        return d
+
 
 def fetch_production(country_code='FO', session=None):
     r = session or requests.session()
     url = 'https://w3.sev.fo/hagtol/xml/xkiefjSDKFjeijgjdkjf3847tgfjlkfdgnlsnfvm.xml'
     response = r.get(url)
     obj = ET.fromstring(response.content)[0]
-    
+
     data = {
         'countryCode': country_code,
         'capacity': {},
@@ -54,7 +58,8 @@ def fetch_production(country_code='FO', session=None):
             # E stands for Energy
             tag = item.tag.replace('Sev_E', '')
             key = getDataKey(tag)
-            if not key: continue
+            if not key:
+                continue
             # Power (MW)
             value = float(item.text.replace(',', '.'))
             data['production'][key] = data['production'].get(key, 0) + value
@@ -63,9 +68,11 @@ def fetch_production(country_code='FO', session=None):
             pass
 
     # At least 10MW should be produced
-    if sum([v for k, v in data['production'].items()]) < 10: return None
+    if sum([v for k, v in data['production'].items()]) < 10:
+        return None
     # The hydro key should be defined
-    if data['production'].get('hydro', None) is None: return None
+    if data['production'].get('hydro', None) is None:
+        return None
 
     return data
 

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import arrow
 import requests
 import xml.etree.ElementTree as ET
@@ -62,7 +63,7 @@ def fetch_production(country_code='FO', session=None):
             pass
 
     # At least 10MW should be produced
-    if sum([v for k, v in data['production'].iteritems()]) < 10: return None
+    if sum([v for k, v in data['production'].items()]) < 10: return None
     # The hydro key should be defined
     if data['production'].get('hydro', None) is None: return None
 
@@ -70,4 +71,4 @@ def fetch_production(country_code='FO', session=None):
 
 
 if __name__ == '__main__':
-    print fetch_production()
+    print(fetch_production())

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import arrow
 import requests
 import xml.etree.ElementTree as ET
@@ -17,6 +18,7 @@ MAP_STORAGE = {
     'Pompage': 'hydro',
 }
 
+
 def fetch_production(country_code='FR', session=None):
     r = session or requests.session()
     formatted_date = arrow.now(tz='Europe/Paris').format('DD/MM/YYYY')
@@ -31,16 +33,18 @@ def fetch_production(country_code='FR', session=None):
         'source': 'rte-france.com',
     }
     for item in mixtr.getchildren():
-        if item.get('granularite') != 'Global': continue
+        if item.get('granularite') != 'Global':
+            continue
         key = item.get('v')
         value = None
-        for value in item.getchildren(): pass
+        for value in item.getchildren():
+            pass
         if key in MAP_GENERATION:
             data['production'][MAP_GENERATION[key]] = float(value.text)
         elif key in MAP_STORAGE:
             data['storage'][MAP_STORAGE[key]] = -1 * float(value.text)
 
-    data['datetime'] = arrow.get(arrow.get(obj[1].text).datetime, 
+    data['datetime'] = arrow.get(arrow.get(obj[1].text).datetime,
         'Europe/Paris').replace(minutes=+(int(value.attrib['periode']) * 15.0)).datetime
 
     # Fetch imports
@@ -63,12 +67,13 @@ def fetch_production(country_code='FR', session=None):
 
     return data
 
+
 def fetch_price(country_code, session=None, from_date=None, to_date=None):
     r = session or requests.session()
     dt_now = arrow.now(tz='Europe/Paris')
     formatted_from = from_date or dt_now.format('DD/MM/YYYY')
     formatted_to = to_date or dt_now.format('DD/MM/YYYY')
-    
+
     url = 'http://www.rte-france.com/getEco2MixXml.php?type=donneesMarche&dateDeb={}&dateFin={}&mode=NORM'.format(formatted_from, formatted_to)
     response = r.get(url)
     obj = ET.fromstring(response.content)
@@ -80,17 +85,21 @@ def fetch_price(country_code, session=None, from_date=None, to_date=None):
     date_str = mixtr.get('date')
     date = arrow.get(arrow.get(date_str).datetime, 'Europe/Paris')
     for country_item in mixtr.getchildren():
-        if country_item.get('granularite') != 'Global': continue
-        country_c=country_item.get('perimetre')
-        if country_code != country_c: continue
+        if country_item.get('granularite') != 'Global':
+            continue
+        country_c = country_item.get('perimetre')
+        if country_code != country_c:
+            continue
         value = None
         for value in country_item.getchildren():
-            if value.text == 'ND': continue
-            datetime=date.replace(hours=+int(value.attrib['periode'])).datetime
-            if datetime > dt_now: continue
+            if value.text == 'ND':
+                continue
+            datetime = date.replace(hours=+int(value.attrib['periode'])).datetime
+            if datetime > dt_now:
+                continue
             datetimes.append(datetime)
             prices.append(float(value.text))
-    
+
     data = {
         'countryCode': country_code,
         'currency': 'EUR',
@@ -99,6 +108,7 @@ def fetch_price(country_code, session=None, from_date=None, to_date=None):
         'source': 'rte-france.com',
     }
     return data
+
 
 if __name__ == '__main__':
     print(fetch_production())

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import arrow
 import requests
 import xml.etree.ElementTree as ET
@@ -100,4 +101,4 @@ def fetch_price(country_code, session=None, from_date=None, to_date=None):
     return data
 
 if __name__ == '__main__':
-    print fetch_production()
+    print(fetch_production())

--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from bs4 import BeautifulSoup
+from __future__ import print_function
+
 from collections import defaultdict
 from datetime import datetime
-from dateutil import parser, tz
+from io import StringIO
 from operator import itemgetter
+
 import pandas as pd
 import requests
-from StringIO import StringIO
+from bs4 import BeautifulSoup
+from dateutil import parser, tz
 
 thermal_url = 'http://www.soni.ltd.uk/DownloadCentre/aspx/FuelMix.aspx'
 wind_url = 'http://www.soni.ltd.uk/DownloadCentre/aspx/SystemOutput.aspx'
 exchange_url = 'http://www.soni.ltd.uk/DownloadCentre/aspx/MoyleTie.aspx'
-#Positive values represent imports to Northern Ireland.
-#Negative value represent exports from Northern Ireland.
+# Positive values represent imports to Northern Ireland.
+# Negative value represent exports from Northern Ireland.
 
 
-def get_data(url, session = None):
+def get_data(url, session=None):
     """
     Requests data from a specified url in CSV format.
     Returns a response.text object.
@@ -30,15 +33,15 @@ def get_data(url, session = None):
                 'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
               }
 
-    pagereq = requests.get(url, headers = headers)
+    pagereq = requests.get(url, headers=headers)
     soup = BeautifulSoup(pagereq.text, 'html.parser')
 
-    #Find and define parameters needed to send a POST request for the actual data.
-    viewstategenerator = soup.find("input", attrs = {'id': '__VIEWSTATEGENERATOR'})['value']
-    viewstate = soup.find("input", attrs = {'id': '__VIEWSTATE'})['value']
-    eventvalidation = soup.find("input", attrs = {'id': '__EVENTVALIDATION'})['value']
+    # Find and define parameters needed to send a POST request for the actual data.
+    viewstategenerator = soup.find("input", attrs={'id': '__VIEWSTATEGENERATOR'})['value']
+    viewstate = soup.find("input", attrs={'id': '__VIEWSTATE'})['value']
+    eventvalidation = soup.find("input", attrs={'id': '__EVENTVALIDATION'})['value']
 
-    #Set date for post request.
+    # Set date for post request.
     current_date = datetime.now().date()
     month = current_date.month
     day = current_date.day
@@ -66,7 +69,7 @@ def get_data(url, session = None):
                    'Content-Type': 'application/x-www-form-urlencoded'
                   }
 
-    datareq = s.post(url, headers = postheaders, data = postdata)
+    datareq = s.post(url, headers=postheaders, data=postdata)
 
     return datareq.text
 
@@ -77,7 +80,7 @@ def add_default_tz(timestamp):
     """
 
     NIR = tz.gettz('Europe/Belfast')
-    modified_timestamp = timestamp.replace(tzinfo = timestamp.tzinfo or NIR)
+    modified_timestamp = timestamp.replace(tzinfo=timestamp.tzinfo or NIR)
 
     return modified_timestamp
 
@@ -87,9 +90,10 @@ def create_thermal_df(text_data):
     Turns thermal csv data into a usable dataframe.
     """
 
-    cols_to_use = [0,1,2,3,4,5]
-    df_thermal = pd.read_csv(StringIO(text_data.decode('utf-8')), usecols = cols_to_use)
-    df_thermal.fillna(0.0, inplace = True)
+    cols_to_use = [0, 1, 2, 3, 4, 5]
+    df_thermal = pd.read_csv(StringIO(text_data),
+                             usecols=cols_to_use)
+    df_thermal.fillna(0.0, inplace=True)
 
     return df_thermal
 
@@ -99,9 +103,10 @@ def create_wind_df(text_data):
     Turns wind csv data into a usable dataframe.
     """
 
-    cols_to_use = [0,1]
-    df_wind = pd.read_csv(StringIO(text_data.decode('utf-8')), usecols = cols_to_use)
-    df_wind.fillna(0.0, inplace = True)
+    cols_to_use = [0, 1]
+    df_wind = pd.read_csv(StringIO(text_data),
+                          usecols=cols_to_use)
+    df_wind.fillna(0.0, inplace=True)
 
     return df_wind
 
@@ -111,8 +116,8 @@ def create_exchange_df(text_data):
     Turns exchange csv data into a usable dataframe.
     """
 
-    df_exchange = pd.read_csv(StringIO(text_data.decode('utf-8')))
-    df_exchange.fillna(0.0, inplace = True)
+    df_exchange = pd.read_csv(StringIO(text_data))
+    df_exchange.fillna(0.0, inplace=True)
 
     return df_exchange
 
@@ -146,7 +151,8 @@ def wind_processor(df):
         snapshot = {}
         snapshot['datetime'] = row['TimeStamp']
         snapshot['wind'] = row['Total_Wind_Generated_MW']
-        if snapshot['wind'] > -20: snapshot['wind'] = max(snapshot['wind'], 0)
+        if snapshot['wind'] > -20:
+            snapshot['wind'] = max(snapshot['wind'], 0)
         datapoints.append(snapshot)
 
     return datapoints
@@ -158,10 +164,11 @@ def moyle_processor(df):
     Returns a list.
     """
 
-    datapoints =[]
+    datapoints = []
     for index, row in df.iterrows():
         snapshot = {}
-        snapshot['datetime'] = add_default_tz(parser.parse(row['TimeStamp'], dayfirst=True))
+        snapshot['datetime'] = add_default_tz(parser.parse(row['TimeStamp'],
+                                                           dayfirst=True))
         snapshot['netFlow'] = row['Total_Moyle_Load_MW']
         snapshot['source'] = 'soni.ltd.uk'
         snapshot['sortedCountryCodes'] = 'GB->GB-NIR'
@@ -176,13 +183,15 @@ def IE_processor(df):
     Returns a list.
     """
 
-    datapoints =[]
+    datapoints = []
     for index, row in df.iterrows():
         snapshot = {}
-        snapshot['datetime'] = add_default_tz(parser.parse(row['TimeStamp'], dayfirst=True))
-        netFlow = row['Total_Str_Let_Load_MW'] + row['Total_Enn_Cor_Load_MW'] + \
-                  row['Total_Tan_Lou_Load_MW']
-        snapshot['netFlow'] = -1*(netFlow)
+        snapshot['datetime'] = add_default_tz(parser.parse(row['TimeStamp'],
+                                                           dayfirst=True))
+        netFlow = (row['Total_Str_Let_Load_MW'] +
+                   row['Total_Enn_Cor_Load_MW'] +
+                   row['Total_Tan_Lou_Load_MW'])
+        snapshot['netFlow'] = -1 * (netFlow)
         snapshot['source'] = 'soni.ltd.uk'
         snapshot['sortedCountryCodes'] = 'GB-NIR->IE'
         datapoints.append(snapshot)
@@ -198,7 +207,7 @@ def merge_production(thermal_data, wind_data):
 
     total_production = thermal_data + wind_data
 
-    #Join thermal and wind dicts on 'datetime' key.
+    # Join thermal and wind dicts on 'datetime' key.
     d = defaultdict(dict)
     for elem in total_production:
         d[elem['datetime']].update(elem)
@@ -211,7 +220,7 @@ def merge_production(thermal_data, wind_data):
     return joined_data
 
 
-def fetch_production(country_code = 'GB-NIR', session = None):
+def fetch_production(country_code='GB-NIR', session=None):
     """
     Requests the last known production mix (in MW) of a given country
         Arguments:
@@ -269,7 +278,7 @@ def fetch_production(country_code = 'GB-NIR', session = None):
     return production_mix_by_quarter_hour
 
 
-def fetch_exchange(country_code1, country_code2, session = None):
+def fetch_exchange(country_code1, country_code2, session=None):
     """Requests the last known power exchange (in MW) between two countries
     Arguments:
     country_code (optional) -- used in case a parser is able to fetch multiple countries

--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 from collections import defaultdict
 from datetime import datetime
@@ -29,9 +26,9 @@ def get_data(url, session=None):
     s = session or requests.Session()
 
     headers = {
-                'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-              }
+        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:55.0) Gecko/20100101 Firefox/55.0',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+    }
 
     pagereq = requests.get(url, headers=headers)
     soup = BeautifulSoup(pagereq.text, 'html.parser')

--- a/parsers/GT.py
+++ b/parsers/GT.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # The arrow library is used to handle datetimes
+from __future__ import print_function
 import arrow
 # The request library is used to fetch content through HTTP
 import requests
@@ -144,7 +145,7 @@ def fetch_consumption(country_code='GT', session=None):
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
-    print 'fetch_production() ->'
-    print fetch_production()
-    print 'fetch_consumption() ->'
-    print fetch_consumption()
+    print('fetch_production() ->')
+    print(fetch_production())
+    print('fetch_consumption() ->')
+    print(fetch_consumption())

--- a/parsers/GT.py
+++ b/parsers/GT.py
@@ -1,8 +1,6 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 # The arrow library is used to handle datetimes
-from __future__ import print_function
 import arrow
 # The request library is used to fetch content through HTTP
 import requests
@@ -23,47 +21,47 @@ MAP_GENERATION = {
 
 
 def fetch_hourly_production(country_code, obj, hour, date):
-    
-    #output frame
+
+    # output frame
     data = {
         'countryCode': country_code,
         'production': {},
         'storage': {},
         'source': 'amm.org.gt',
     }
-    
-    #Fill datetime variable
-    data['datetime'] = arrow.get(date, 'DD/MM/YYYY').replace(tzinfo=tz_gt, hour=hour).datetime   
-    
-    #First add 'Biomasa' and 'Biogas' together to make 'biomass' variable (and avoid negative values)
-    data['production']['biomass'] = max(obj[obj['tipo'] == 'Biomasa'].potencia.iloc[0],0) + max(obj[obj['tipo'] == 'Biogas'].potencia.iloc[0],0)
-    #Then fill the other sources directly with the MAP_GENERATION frame
+
+    # Fill datetime variable
+    data['datetime'] = arrow.get(date, 'DD/MM/YYYY').replace(tzinfo=tz_gt, hour=hour).datetime
+
+    # First add 'Biomasa' and 'Biogas' together to make 'biomass' variable (and avoid negative values)
+    data['production']['biomass'] = max(obj[obj['tipo'] == 'Biomasa'].potencia.iloc[0], 0) + max(obj[obj['tipo'] == 'Biogas'].potencia.iloc[0], 0)
+    # Then fill the other sources directly with the MAP_GENERATION frame
     for i_type in MAP_GENERATION.keys():
         val = obj[obj['tipo'] == MAP_GENERATION[i_type]].potencia.iloc[0]
         if i_type == 'oil' and val > -1:
             # Set to 0 values that are not too small
             val = max(0, val)
         data['production'][i_type] = val
-    
+
     return data
 
 
 def fetch_production(country_code='GT', session=None):
-    #Define actual and last day (for midnight data)
+    # Define actual and last day (for midnight data)
     now = arrow.now(tz=tz_gt)
     formatted_date = now.format('DD/MM/YYYY')
     past_formatted_date = arrow.get(formatted_date, 'DD/MM/YYYY').shift(days=-1).format('DD/MM/YYYY')
-    
-    #Define output frame
+
+    # Define output frame
     actual_hour = now.hour
-    data = [dict() for h in range(actual_hour+1)]
+    data = [dict() for h in range(actual_hour + 1)]
 
-    #initial path for url to request
-    url_init = 'http://wl.amm.org.gt/AMM_LectorDePotencias-AMM_GraficasWs-context-root/jersey/CargaPotencias/graficaAreaScada/' 
+    # initial path for url to request
+    url_init = 'http://wl.amm.org.gt/AMM_LectorDePotencias-AMM_GraficasWs-context-root/jersey/CargaPotencias/graficaAreaScada/'
 
-    #Start with data for midnight
+    # Start with data for midnight
     url = url_init + past_formatted_date
-    #Request and rearange in DF
+    # Request and rearange in DF
     r = session or requests.session()
     response = r.get(url)
     obj = response.json()
@@ -71,16 +69,16 @@ def fetch_production(country_code='GT', session=None):
     obj_h = obj_df[obj_df.hora == '24']
     data_temp = fetch_hourly_production(country_code, obj_h, 0, formatted_date)
     data[0] = data_temp
-    
-    #Fill data for the other hours until actual hour
-    if actual_hour>1:
+
+    # Fill data for the other hours until actual hour
+    if actual_hour > 1:
         url = url_init + formatted_date
-        #Request and rearange in DF
+        # Request and rearange in DF
         r = session or requests.session()
         response = r.get(url)
         obj = response.json()
         obj_df = pd.DataFrame(obj)
-        for h in range(1,actual_hour+1):
+        for h in range(1, actual_hour + 1):
             obj_h = obj_df[obj_df.hora == str(h)]
             data_temp = fetch_hourly_production(country_code, obj_h, h, formatted_date)
             data[h] = data_temp
@@ -89,36 +87,36 @@ def fetch_production(country_code='GT', session=None):
 
 
 def fetch_hourly_consumption(country_code, obj, hour, date):
-    #output frame
+    # output frame
     data = {
         'countryCode': country_code,
         'consumption': {},
         'source': 'amm.org.gt',
     }
-    #Fill datetime variable
-    data['datetime'] = arrow.get(date, 'DD/MM/YYYY').replace(tzinfo=tz_gt, hour=hour).datetime   
-    #Fill consumption variable
+    # Fill datetime variable
+    data['datetime'] = arrow.get(date, 'DD/MM/YYYY').replace(tzinfo=tz_gt, hour=hour).datetime
+    # Fill consumption variable
     data['consumption'] = obj[obj['tipo'] == 'Dem SNI'].potencia.iloc[0]
-    
+
     return data
 
 
 def fetch_consumption(country_code='GT', session=None):
-    #Define actual and last day (for midnight data)
+    # Define actual and last day (for midnight data)
     now = arrow.now(tz=tz_gt)
     formatted_date = now.format('DD/MM/YYYY')
     past_formatted_date = arrow.get(formatted_date, 'DD/MM/YYYY').shift(days=-1).format('DD/MM/YYYY')
-    
-    #Define output frame
+
+    # Define output frame
     actual_hour = now.hour
-    data = [dict() for h in range(actual_hour+1)]
+    data = [dict() for h in range(actual_hour + 1)]
 
-    #initial path for url to request
-    url_init = 'http://wl.amm.org.gt/AMM_LectorDePotencias-AMM_GraficasWs-context-root/jersey/CargaPotencias/graficaAreaScada/' 
+    # initial path for url to request
+    url_init = 'http://wl.amm.org.gt/AMM_LectorDePotencias-AMM_GraficasWs-context-root/jersey/CargaPotencias/graficaAreaScada/'
 
-    #Start with data for midnight
+    # Start with data for midnight
     url = url_init + past_formatted_date
-    #Request and rearange in DF
+    # Request and rearange in DF
     r = session or requests.session()
     response = r.get(url)
     obj = response.json()
@@ -126,16 +124,16 @@ def fetch_consumption(country_code='GT', session=None):
     obj_h = obj_df[obj_df.hora == '24']
     data_temp = fetch_hourly_consumption(country_code, obj_h, 0, formatted_date)
     data[0] = data_temp
-    
-    #Fill data for the other hours until actual hour
-    if actual_hour>1:
+
+    # Fill data for the other hours until actual hour
+    if actual_hour > 1:
         url = url_init + formatted_date
-        #Request and rearange in DF
+        # Request and rearange in DF
         r = session or requests.session()
         response = r.get(url)
         obj = response.json()
         obj_df = pd.DataFrame(obj)
-        for h in range(1,actual_hour+1):
+        for h in range(1, actual_hour + 1):
             obj_h = obj_df[obj_df.hora == str(h)]
             data_temp = fetch_hourly_consumption(country_code, obj_h, h, formatted_date)
             data[h] = data_temp

--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from requests import Session
 from parsers import countrycode
 from parsers import web
@@ -70,6 +71,6 @@ def fetch_consumption(country_code='IN-AP', session=None):
 
 if __name__ == '__main__':
     session = Session()
-    print fetch_production('IN-AP', session)
-    print fetch_consumption('IN-AP', session)
+    print(fetch_production('IN-AP', session))
+    print(fetch_consumption('IN-AP', session))
 

--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 from requests import Session
 from parsers import countrycode
 from parsers import web
@@ -73,4 +74,3 @@ if __name__ == '__main__':
     session = Session()
     print(fetch_production('IN-AP', session))
     print(fetch_consumption('IN-AP', session))
-

--- a/parsers/IN_CT.py
+++ b/parsers/IN_CT.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 from requests import Session
 from parsers.lib import web
 from parsers.lib import countrycode
@@ -22,6 +23,7 @@ def fetch_consumption(country_code='IN-CT', session=None):
     }
 
     return data
+
 
 def fetch_production(country_code='IN-CT', session=None):
     """Fetch Chhattisgarh production"""

--- a/parsers/IN_CT.py
+++ b/parsers/IN_CT.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from requests import Session
 from parsers.lib import web
 from parsers.lib import countrycode
@@ -57,5 +58,5 @@ def fetch_production(country_code='IN-CT', session=None):
 
 if __name__ == '__main__':
     session = Session()
-    print fetch_production('IN-CT', session)
-    print fetch_consumption('IN-CT', session)
+    print(fetch_production('IN-CT', session))
+    print(fetch_consumption('IN-CT', session))

--- a/parsers/IN_DL.py
+++ b/parsers/IN_DL.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 from requests import Session
 from parsers.lib import web
 from parsers.lib import countrycode

--- a/parsers/IN_DL.py
+++ b/parsers/IN_DL.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from requests import Session
 from parsers.lib import web
 from parsers.lib import countrycode
@@ -86,5 +87,5 @@ def read_value(row):
 
 if __name__ == '__main__':
     session = Session()
-    print fetch_production('IN-DL', session)
-    print fetch_consumption('IN-DL', session)
+    print(fetch_production('IN-DL', session))
+    print(fetch_consumption('IN-DL', session))

--- a/parsers/IN_KA.py
+++ b/parsers/IN_KA.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from requests import Session
 from parsers.lib.exceptions import ParserException
 from parsers.lib import web
@@ -156,5 +157,5 @@ def fetch_production(country_code='IN-KA', session=None):
 
 if __name__ == '__main__':
     session = Session()
-    print fetch_production('IN-KA', session)
-    print fetch_consumption('IN-KA', session)
+    print(fetch_production('IN-KA', session))
+    print(fetch_consumption('IN-KA', session))

--- a/parsers/IN_KA.py
+++ b/parsers/IN_KA.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 from requests import Session
 from parsers.lib.exceptions import ParserException
 from parsers.lib import web

--- a/parsers/IN_PB.py
+++ b/parsers/IN_PB.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from requests import Session
 from re import search, findall, M, S, I, sub
 from arrow import utcnow, get
@@ -110,5 +111,5 @@ def fetch_consumption(country_code='IN-PB', session=None):
 
 if __name__ == '__main__':
     session = Session()
-    print fetch_production('IN-PB', session)
-    print fetch_consumption('IN-PB', session)
+    print(fetch_production('IN-PB', session))
+    print(fetch_consumption('IN-PB', session))

--- a/parsers/IN_PB.py
+++ b/parsers/IN_PB.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 from requests import Session
 from re import search, findall, M, S, I, sub
 from arrow import utcnow, get
@@ -51,7 +52,7 @@ def fetch_production(country_code='IN-PB', session=None):
     thermal_text = thermal_match.group(0)
     thermal_value = findall('\d+', thermal_text)[0]
 
-    ipp_match = search('Total IPPs = \d+',response_text)
+    ipp_match = search('Total IPPs = \d+', response_text)
     ipp_text = ipp_match.group(0)
     ipp_value = findall('\d+', ipp_text)[0]
 
@@ -86,7 +87,7 @@ def fetch_consumption(country_code='IN-PB', session=None):
                                           session)
     date_text = read_text_by_regex('(\d+/\d+/\d+)', response_text)
     time_text = read_text_by_regex('(\d+:\d+:\d+)', response_text)
-    
+
     india_date = date_time_strings_to_kolkata_date(date_text, "MM/DD/YYYY", time_text, "HH:mm:ss")
 
     punjab_match = search('<tr>(.*?)PUNJAB(.*?)</tr>', response_text, M|I|S).group(0)

--- a/parsers/IS.py
+++ b/parsers/IS.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import requests
 from datetime import datetime
 from collections import defaultdict
@@ -74,4 +75,4 @@ def fetch_production(country_code='IS', session=None):
     return data
 
 if __name__ == '__main__':
-    print fetch_production()
+    print(fetch_production())

--- a/parsers/IS.py
+++ b/parsers/IS.py
@@ -1,8 +1,8 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import requests
 from datetime import datetime
 from collections import defaultdict
-import xml.etree.ElementTree as ET
 import json
 
 STATIONS = {
@@ -35,6 +35,7 @@ STATIONS = {
     'SVA': 'geothermal',
 }
 
+
 def fetch_production(country_code='IS', session=None):
     # Disabled for now due to https://github.com/corradio/electricitymap/issues/140
     return
@@ -48,10 +49,10 @@ def fetch_production(country_code='IS', session=None):
     # Set zero values for energy sources Iceland doesn't use at all
     # Iceland does use some wind and gas but we don't have data for those
     production = defaultdict(float)
-    production["solar"] = 0;
-    production["biomass"] = 0;
-    production["nuclear"] = 0;
-    production["coal"] = 0;
+    production["solar"] = 0
+    production["biomass"] = 0
+    production["nuclear"] = 0
+    production["coal"] = 0
 
     # Calculate production values for each power station
     # The Landsnet API includes measurements for non-generating
@@ -59,7 +60,7 @@ def fetch_production(country_code='IS', session=None):
     for key, value in STATIONS.items():
         items = [item for item in json_obj if item["substation"] == key and item["MW"] >= 0]
         mw = sum(item['MW'] for item in items)
-        production[value] = production[value] + mw;
+        production[value] = production[value] + mw
 
     # Get datetime for last update (e.g. 2017-02-02T14:35:00)
     totalpowerflow = next(item for item in json_obj if item["key"] == "TOTAL_POWER_FLOW")
@@ -73,6 +74,7 @@ def fetch_production(country_code='IS', session=None):
         'source': 'landsnet.is',
     }
     return data
+
 
 if __name__ == '__main__':
     print(fetch_production())

--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
 """Parser for Moldova."""
 

--- a/parsers/MY_WM.py
+++ b/parsers/MY_WM.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 #Parser for Peninsular Malaysia (West Malaysia).
 #This does not include the states of Sarawak and Sarawak.
 #There is pumped storage in the Peninsular but no data is currently available.
 #https://www.scribd.com/document/354635277/Doubling-Up-in-Malaysia-International-Water-Power
 
-from __future__ import print_function
 from bs4 import BeautifulSoup
 from collections import defaultdict
 import datetime

--- a/parsers/MY_WM.py
+++ b/parsers/MY_WM.py
@@ -5,6 +5,7 @@
 #There is pumped storage in the Peninsular but no data is currently available.
 #https://www.scribd.com/document/354635277/Doubling-Up-in-Malaysia-International-Water-Power
 
+from __future__ import print_function
 from bs4 import BeautifulSoup
 from collections import defaultdict
 import datetime
@@ -88,7 +89,7 @@ def data_processer(rawdata):
         if gen_type not in fuel_mapping.keys():
             unmapped.append(gen_type)
 
-    mapped_generation = [(fuel_mapping.get(gen_type, 'unknown'), val) for gen_type, val in current_generation.iteritems()]
+    mapped_generation = [(fuel_mapping.get(gen_type, 'unknown'), val) for gen_type, val in current_generation.items()]
 
     generationDict = defaultdict(lambda: 0.0)
 
@@ -103,7 +104,7 @@ def data_processer(rawdata):
         generationDict[key] = 0.0
 
     for gen_type in unmapped:
-        print '{} is missing from the MY generation type mapping!'.format(gen_type)
+        print('{} is missing from the MY generation type mapping!'.format(gen_type))
 
     return converted_time_string, dict(generationDict)
 

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import arrow
 from collections import defaultdict
@@ -58,12 +55,17 @@ PLANT_CLASSIFICATIONS = [
     'hydro'         # C. Fonseca
 ]
 
-REFERENCE_TOTAL_PRODUCTION = 433 # MW
+REFERENCE_TOTAL_PRODUCTION = 433  # MW
+
+
+# TODO: why return d no matter which way the if goes?!?
 def validate_datapoint(d):
     total = sum([v for k, v in d['production'].items()])
-    if total > 5 * REFERENCE_TOTAL_PRODUCTION \
-        or total < 1.0 / 5 * REFERENCE_TOTAL_PRODUCTION: return d
-    else: return d
+    if (total > 5 * REFERENCE_TOTAL_PRODUCTION or
+            total < 1.0 / 5 * REFERENCE_TOTAL_PRODUCTION):
+        return d
+    else:
+        return d
 
 
 def extract_text(full_text, start_text, end_text=None):

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import arrow
 from collections import defaultdict
@@ -59,7 +60,7 @@ PLANT_CLASSIFICATIONS = [
 
 REFERENCE_TOTAL_PRODUCTION = 433 # MW
 def validate_datapoint(d):
-    total = sum([v for k, v in d['production'].iteritems()])
+    total = sum([v for k, v in d['production'].items()])
     if total > 5 * REFERENCE_TOTAL_PRODUCTION \
         or total < 1.0 / 5 * REFERENCE_TOTAL_PRODUCTION: return d
     else: return d

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -9,13 +10,15 @@ from bs4 import BeautifulSoup
 
 timezone = 'Pacific/Auckland'
 
+
 def fetch(session=None):
     r = session or requests.session()
     url = 'https://www.transpower.co.nz/power-system-live-data'
     response = r.get(url)
     soup = BeautifulSoup(response.text, 'html.parser')
     for item in soup.find_all('script'):
-        if 'src' in item.attrs: continue
+        if 'src' in item.attrs:
+            continue
         body = item.contents[0]
         if not body.startswith('jQuery.extend(Drupal.settings'):
             continue
@@ -121,11 +124,11 @@ def fetch_exchange(country_code1='NZ-NZN', country_code2='NZ-NZS', session=None)
             continue
         netFlow = item[1]
         data.append({
-              'sortedCountryCodes': 'NZ-NZN->NZ-NZS',
-              'datetime': datetime.datetime,
-              'netFlow': -1 * netFlow,
-              'source': 'transpower.co.nz'
-          })
+            'sortedCountryCodes': 'NZ-NZN->NZ-NZS',
+            'datetime': datetime.datetime,
+            'netFlow': -1 * netFlow,
+            'source': 'transpower.co.nz'
+        })
 
     return data
 

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -132,9 +133,9 @@ def fetch_exchange(country_code1='NZ-NZN', country_code2='NZ-NZS', session=None)
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production(NZ-NZN) ->'
-    print fetch_production('NZ-NZN')
-    print 'fetch_production(NZ-NZS) ->'
-    print fetch_production('NZ-NZS')
-    print 'fetch_exchange() ->'
-    print fetch_exchange()
+    print('fetch_production(NZ-NZN) ->')
+    print(fetch_production('NZ-NZN'))
+    print('fetch_production(NZ-NZS) ->')
+    print(fetch_production('NZ-NZS'))
+    print('fetch_exchange() ->')
+    print(fetch_exchange())

--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 # The arrow library is used to handle datetimes
+from __future__ import print_function
 import arrow
 # The request library is used to fetch content through HTTP
 import requests
@@ -39,6 +40,7 @@ def fetch_production(country_code='PA', session=None):
     r = session or requests.session()
     url = 'http://sitr.cnd.com.pa/m/pub/gen.html'
     response = r.get(url)
+    response.encoding = 'utf-8'
     html_doc = response.text
     soup = BeautifulSoup(html_doc, 'html.parser')
     productions = soup.find('table',{'class':'sitr-pie-layout'}).find_all('span')
@@ -57,7 +59,7 @@ def fetch_production(country_code='PA', session=None):
     }
     for prod in productions:
         prod_data = prod.string.split(' ')
-        production_mean = map_generation[prod_data[0].encode("latin-1")]
+        production_mean = map_generation[prod_data[0]]
         production_value = float(prod_data[1])
         data['production'][production_mean] = production_value
 
@@ -72,5 +74,5 @@ def fetch_production(country_code='PA', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
+    print('fetch_production() ->')
+    print(fetch_production())

--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -1,11 +1,12 @@
-# coding: utf-8
+#!/usr/bin/env python3
+
 # The arrow library is used to handle datetimes
-from __future__ import print_function
 import arrow
 # The request library is used to fetch content through HTTP
 import requests
 # The BeautifulSoup library is used to parse HTML
 from bs4 import BeautifulSoup
+
 
 def fetch_production(country_code='PA', session=None):
     """Requests the last known production mix (in MW) of a given country
@@ -43,7 +44,7 @@ def fetch_production(country_code='PA', session=None):
     response.encoding = 'utf-8'
     html_doc = response.text
     soup = BeautifulSoup(html_doc, 'html.parser')
-    productions = soup.find('table',{'class':'sitr-pie-layout'}).find_all('span')
+    productions = soup.find('table', {'class': 'sitr-pie-layout'}).find_all('span')
     map_generation = {
       'Hídrica': 'hydro',
       'Eólica': 'wind',
@@ -64,7 +65,7 @@ def fetch_production(country_code='PA', session=None):
         data['production'][production_mean] = production_value
 
     # Parse the datetime and return a python datetime object
-    spanish_date = soup.find('div',{'class':'sitr-update'}).find('span').string
+    spanish_date = soup.find('div', {'class': 'sitr-update'}).find('span').string
     date = arrow.get(spanish_date, 'DD-MMMM-YYYY H:mm:ss', locale="es", tzinfo="America/Panama")
     data['datetime'] = date.datetime
 

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import arrow
 import dateutil
 import requests
@@ -20,7 +21,7 @@ MAP_GENERATION = {
 }
 
 def validate(datapoint):
-    if sum([v for k,v in datapoint['production'].iteritems() if v is not None]) > 0 \
+    if sum([v for k,v in datapoint['production'].items() if v is not None]) > 0 \
         and datapoint['production'].get('gas', None) is not None:
         return datapoint
     else:
@@ -46,7 +47,7 @@ def fetch_production(country_code='PE', session=None):
     datetimes = []
 
     for serie in obj:
-        k = serie['Name'].encode('utf-8')
+        k = serie['Name']
         if not k in MAP_GENERATION:
             raise Exception('Unknown production type %s' % k)
         for v in serie['Data']:
@@ -66,8 +67,8 @@ def fetch_production(country_code='PE', session=None):
             data[i]['production'][MAP_GENERATION[k]] = \
                 data[i]['production'].get(MAP_GENERATION[k], 0) + v['Valor'] / interval_hours
 
-    return filter(lambda x: validate(x) is not None, data)
+    return list(filter(lambda x: validate(x) is not None, data))
 
 
 if __name__ == '__main__':
-    print fetch_production()
+    print(fetch_production())

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -1,7 +1,5 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 import dateutil
 import requests
@@ -21,7 +19,7 @@ MAP_GENERATION = {
 }
 
 def validate(datapoint):
-    if sum([v for k,v in datapoint['production'].items() if v is not None]) > 0 \
+    if sum([v for k, v in datapoint['production'].items() if v is not None]) > 0 \
         and datapoint['production'].get('gas', None) is not None:
         return datapoint
     else:

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from collections import defaultdict
 

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -1,7 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-from __future__ import print_function
+#!/usr/bin/env python3
 
 from collections import defaultdict
 

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 import requests
@@ -10,11 +8,11 @@ import re
 from collections import defaultdict
 from operator import itemgetter
 
-#This parser gets hourly electricity generation data from ut.com.sv for El Salvador.
-#El Salvador does have wind generation but there is no data available.
-#Fossil fuel generation is grouped under 'thermal' with no further breakdown given.
+# This parser gets hourly electricity generation data from ut.com.sv for El Salvador.
+# El Salvador does have wind generation but there is no data available.
+# Fossil fuel generation is grouped under 'thermal' with no further breakdown given.
 
-#Thanks to jarek for figuring out how to make the correct POST request to the data url.
+# Thanks to jarek for figuring out how to make the correct POST request to the data url.
 
 url = 'http://estadistico.ut.com.sv/OperacionDiaria.aspx'
 
@@ -193,7 +191,7 @@ def fetch_production(country_code = 'SV', session = None):
     return production_mix_by_hour
 
 
-if __name__ ==  '__main__':
+if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import arrow
 from bs4 import BeautifulSoup
 import requests

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import requests
 import re
 import json

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -1,4 +1,5 @@
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import requests
 import re
 import json
@@ -76,7 +77,7 @@ def fetch_production(country_code='TR', session=None):
       'source': 'mysource.com'
     }
     """
-    session = None # Explicitely make a new session to avoid caching from their server...
+    session = None  # Explicitely make a new session to avoid caching from their server...
     r = session or requests.session()
     tr_datetime = arrow.now().to('Europe/Istanbul').floor('day')
     response = r.get(URL, verify=False)
@@ -102,9 +103,9 @@ def fetch_production(country_code='TR', session=None):
                         data['production'][MAP_GENERATION[prod_type]] += prod_val
 
                 try:
-                    data['datetime'] = tr_datetime.replace(hour = int(datapoint['saat'])).datetime
+                    data['datetime'] = tr_datetime.replace(hour=int(datapoint['saat'])).datetime
                 except ValueError:
-                    #24 is not a valid hour!
+                    # 24 is not a valid hour!
                     data['datetime'] = tr_datetime.datetime
 
                 production_by_hour.append(data)
@@ -112,6 +113,7 @@ def fetch_production(country_code='TR', session=None):
         raise Exception('Extracted data was None')
 
     return production_by_hour
+
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""

--- a/parsers/TW.py
+++ b/parsers/TW.py
@@ -1,35 +1,36 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 import arrow
 import requests
-import json
 import pandas
 import dateutil
 
+
 def fetch_production(country_code='TW', session=None):
-    
+
     r = session or requests.session()
     url = 'http://data.taipower.com.tw/opendata01/apply/file/d006001/001.txt'
     response = requests.get(url)
     data = response.json()
-    
+
     dumpDate = data['']
     prodData = data['aaData']
-    
+
     tz = 'Asia/Taipei'
     dumpDate = arrow.get(dumpDate, 'YYYY-MM-DD HH:mm').replace(tzinfo=dateutil.tz.gettz(tz))
- 
-    objData = pandas.DataFrame(prodData);
 
-    objData.columns = ['fueltype','name','capacity','output','percentage','additional']
+    objData = pandas.DataFrame(prodData)
+
+    objData.columns = ['fueltype', 'name', 'capacity', 'output', 'percentage',
+                       'additional']
 
     objData['fueltype'] = objData.fueltype.str.split('(').str[1]
     objData['fueltype'] = objData.fueltype.str.split(')').str[0]
     objData.drop('additional', axis=1, inplace=True)
     objData.drop('percentage', axis=1, inplace=True)
-    
+
     objData = objData.convert_objects(convert_numeric=True)
     production = pandas.DataFrame(objData.groupby('fueltype').sum())
-    production.columns = ['capacity','output']
+    production.columns = ['capacity', 'output']
 
     coal_capacity = production.ix['Coal'].capacity + production.ix['IPP-Coal'].capacity
     gas_capacity = production.ix['LNG'].capacity + production.ix['IPP-LNG'].capacity
@@ -43,23 +44,23 @@ def fetch_production(country_code='TW', session=None):
     # We require the opposite
 
     returndata = {
-		'countryCode': country_code,
+        'countryCode': country_code,
         'datetime': dumpDate.datetime,
-		'production': {
-	        'coal': coal_production,
+        'production': {
+            'coal': coal_production,
             'gas': gas_production,
             'oil': oil_production,
-            'hydro' : production.ix['Hydro'].output,
+            'hydro': production.ix['Hydro'].output,
             'nuclear': production.ix['Nuclear'].output,
             'solar': production.ix['Solar'].output,
             'wind': production.ix['Wind'].output,
             'unknown': production.ix['Co-Gen'].output
         },
         'capacity': {
-    			  'coal': coal_capacity,
+            'coal': coal_capacity,
             'gas': gas_capacity,
             'oil': oil_capacity,
-            'hydro' : production.ix['Hydro'].capacity,
+            'hydro': production.ix['Hydro'].capacity,
             'nuclear': production.ix['Nuclear'].capacity,
             'solar': production.ix['Solar'].capacity,
             'wind': production.ix['Wind'].capacity,
@@ -72,6 +73,7 @@ def fetch_production(country_code='TW', session=None):
     }
 
     return returndata
+
 
 if __name__ == '__main__':
     print(fetch_production())

--- a/parsers/TW.py
+++ b/parsers/TW.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import arrow
 import requests
 import json
@@ -9,10 +10,7 @@ def fetch_production(country_code='TW', session=None):
     r = session or requests.session()
     url = 'http://data.taipower.com.tw/opendata01/apply/file/d006001/001.txt'
     response = requests.get(url)
-    content = response.content
-
-    content = unicode(response.content,"UTF-8")
-    data = json.loads(content)
+    data = response.json()
     
     dumpDate = data['']
     prodData = data['aaData']
@@ -76,4 +74,4 @@ def fetch_production(country_code='TW', session=None):
     return returndata
 
 if __name__ == '__main__':
-    print fetch_production()
+    print(fetch_production())

--- a/parsers/UA.py
+++ b/parsers/UA.py
@@ -1,7 +1,4 @@
-#!/usr/bin/python
-## -*- coding: utf-8 -*-
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import arrow
 import dateutil

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The pandas library is used to parse content through HTTP
@@ -90,5 +91,5 @@ def fetch_production(country_code='US-CA', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
+    print('fetch_production() ->')
+    print(fetch_production())

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -1,12 +1,8 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 # The arrow library is used to handle datetimes
 import arrow
 # The pandas library is used to parse content through HTTP
 import pandas
-# The request library is used to fetch content through HTTP
-import requests
-# The BeautifulSoup library is used to parse HTML
-from bs4 import BeautifulSoup
 
 def fetch_production(country_code='US-CA', session=None):
     """Requests the last known production mix (in MW) of a given country

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 """Real time parser for the New England ISO (NEISO) area."""
+from __future__ import print_function
 
 import arrow
 from collections import defaultdict
@@ -77,7 +78,7 @@ def data_processer(raw_data):
         dt = timestring_converter(time_string)
 
         production = defaultdict(lambda: 0.0)
-        for k, v in datapoint.iteritems():
+        for k, v in datapoint.items():
             #Need to avoid duplicate keys overwriting.
             production[generation_mapping[k]] += v
 

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -1,8 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
+
 
 """Real time parser for the New England ISO (NEISO) area."""
-from __future__ import print_function
-
 import arrow
 from collections import defaultdict
 import requests

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 """Real time parser for the state of New York."""
+from __future__ import print_function
 
 import arrow
 from collections import defaultdict
@@ -59,7 +60,7 @@ def data_parser(df):
 
     mapped_generation = []
     for item in ordered:
-        mapped_types = [(mapping.get(k, k), v) for k, v in item.iteritems()]
+        mapped_types = [(mapping.get(k, k), v) for k, v in item.items()]
 
         #Need to avoid multiple 'unknown' keys overwriting.
         complete_production = defaultdict(lambda: 0.0)

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Real time parser for the state of New York."""
-from __future__ import print_function
-
 import arrow
 from collections import defaultdict
 from operator import itemgetter

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -1,9 +1,8 @@
-#!/usr/bin/python
-# -*- coding: utf-8 -*-
+#!/usr/bin/python3
 
-from __future__ import print_function
 import arrow
-import dateutil, re
+import dateutil
+import re
 import requests
 
 # BeautifulSoup is used to parse HTML to get information

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import arrow
 import dateutil, re
 import requests
@@ -17,7 +18,7 @@ MAP_GENERATION = {
   'Biomasa': 'biomass',
   'Térmica': 'unknown'
 }
-INV_MAP_GENERATION = dict([(v, k) for (k, v) in MAP_GENERATION.iteritems()])
+INV_MAP_GENERATION = dict([(v, k) for (k, v) in MAP_GENERATION.items()])
 
 def parse_page(session):
     r = session or requests.session()
@@ -42,7 +43,7 @@ def parse_page(session):
         key = tds[0].find_all('b')
         # Go back one level up if the b tag is not there
         if not len(key): key = tds[0].find_all('font')
-        k = key[0].contents[0].encode('utf-8')
+        k = key[0].contents[0]
 
         value = tds[1].find_all('b')
         # Go back one level up if the b tag is not there
@@ -116,5 +117,5 @@ def fetch_exchange(country_code1='UY', country_code2='BR-S', session=None):
 
 
 if __name__ == '__main__':
-    print fetch_production()
-    print fetch_exchange('UY', 'BR')
+    print(fetch_production())
+    print(fetch_exchange('UY', 'BR'))

--- a/parsers/example.py
+++ b/parsers/example.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+#!/usr/bin/env python3
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -127,7 +127,7 @@ def fetch_exchange(country_code1='DK', country_code2='NO', session=None):
 
     # Country codes are sorted in order to enable easier indexing in the database
     sorted_country_codes = sorted([country_code1, country_code2])
-    # Here we assume that the net flow returned by the api is the flow from 
+    # Here we assume that the net flow returned by the api is the flow from
     # country1 to country2. A positive flow indicates an export from country1
     # to country2. A negative flow indicates an import.
     netFlow = obj['exchange']

--- a/parsers/example.py
+++ b/parsers/example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -144,9 +145,9 @@ def fetch_exchange(country_code1='DK', country_code2='NO', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production() ->'
-    print fetch_production()
-    print 'fetch_price() ->'
-    print fetch_price()
-    print 'fetch_exchange(DK, NO) ->'
-    print fetch_exchange('DK', 'NO')
+    print('fetch_production() ->')
+    print(fetch_production())
+    print('fetch_price() ->')
+    print(fetch_price())
+    print('fetch_exchange(DK, NO) ->')
+    print(fetch_exchange('DK', 'NO'))

--- a/parsers/lib/AU_battery.py
+++ b/parsers/lib/AU_battery.py
@@ -1,15 +1,14 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """Parser for South Australia's 129MWh battery built by Tesla."""
-from __future__ import print_function
-
 import arrow
 import json
 import requests
 
-#nemlog_url gets generation status in 5 min intervals.
+# nemlog_url gets generation status in 5 min intervals.
 
-def fetch_SA_battery(session = None):
+
+def fetch_SA_battery(session=None):
     """
     Makes a request to the nemlog api for South Australia battery data.
     Returns a float or None.
@@ -30,13 +29,13 @@ def fetch_SA_battery(session = None):
     try:
         latest = json.loads(data[-1])
     except IndexError:
-        #No data available.
+        # No data available.
         return None
 
     state = float(latest["SCADAVALUE"])
 
-    #Source classifies charge/discharge opposite to EM.
-    battery_status = -1*state
+    # Source classifies charge/discharge opposite to EM.
+    battery_status = -1 * state
 
     return battery_status
 

--- a/parsers/lib/AU_battery.py
+++ b/parsers/lib/AU_battery.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
 """Parser for South Australia's 129MWh battery built by Tesla."""
+from __future__ import print_function
 
 import arrow
 import json

--- a/parsers/lib/AU_solar.py
+++ b/parsers/lib/AU_solar.py
@@ -1,5 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import datetime
 

--- a/parsers/lib/AU_solar.py
+++ b/parsers/lib/AU_solar.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import datetime
 

--- a/parsers/lib/exceptions.py
+++ b/parsers/lib/exceptions.py
@@ -21,4 +21,4 @@ class ParserException(Exception):
             country_code_info = " ({0})".format(self.country_code)
         else:
             country_code_info = ""
-        return "{0} Parser{1}: {2}".format(self.parser, country_code_info, self.message)
+        return "{0} Parser{1}: {2}".format(self.parser, country_code_info, self.args[0])

--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -1,36 +1,50 @@
-import arrow, datetime
+import datetime
+
+import arrow
+
 
 def validate_consumption(obj, country_code):
     # Data quality check
     if obj['consumption'] is not None and obj['consumption'] < 0:
-        raise ValueError('%s: consumption has negative value %s' % (country_code, obj['consumption']))
+        raise ValueError('%s: consumption has negative value %s' %
+                         (country_code, obj['consumption']))
+
 
 def validate_exchange(item, k):
     if item.get('sortedCountryCodes', None) != k:
-        raise Exception("Sorted country codes %s and %s don't match" % (item.get('sortedCountryCodes', None), k))
-    if not 'datetime' in item:
+        raise Exception("Sorted country codes %s and %s don't match" %
+                        (item.get('sortedCountryCodes', None), k))
+    if 'datetime' not in item:
         raise Exception('datetime was not returned for %s' % k)
-    if not type(item['datetime']) == datetime.datetime:
-        raise Exception('datetime %s is not valid for %s' % (item['datetime'], k))
+    if type(item['datetime']) != datetime.datetime:
+        raise Exception('datetime %s is not valid for %s' %
+                        (item['datetime'], k))
     if arrow.get(item['datetime']) > arrow.now():
         raise Exception("Data from %s can't be in the future" % k)
 
+
 def validate_production(obj, country_code):
-    if not 'datetime' in obj:
+    if 'datetime' not in obj:
         raise Exception('datetime was not returned for %s' % country_code)
-    if not 'countryCode' in obj:
+    if 'countryCode' not in obj:
         raise Exception('countryCode was not returned for %s' % country_code)
-    if not type(obj['datetime']) == datetime.datetime:
-        raise Exception('datetime %s is not valid for %s' % (obj['datetime'], country_code))
+    if type(obj['datetime']) != datetime.datetime:
+        raise Exception('datetime %s is not valid for %s' %
+                        (obj['datetime'], country_code))
     if obj.get('countryCode', None) != country_code:
-        raise Exception("Country codes %s and %s don't match" % (obj.get('countryCode', None), country_code))
+        raise Exception("Country codes %s and %s don't match" %
+                        (obj.get('countryCode', None), country_code))
     if arrow.get(obj['datetime']) > arrow.now():
         raise Exception("Data from %s can't be in the future" % country_code)
-    if obj.get('production', {}).get('unknown', None) is None and \
-        obj.get('production', {}).get('coal', None) is None and \
-        obj.get('production', {}).get('oil', None) is None and \
-        country_code not in ['CH', 'NO', 'AUS-TAS']:
-        raise Exception("Coal or oil or unknown production value is required for %s" % (country_code))
-    for k, v in obj['production'].iteritems():
-        if v is None: continue
-        if v < 0: raise ValueError('%s: key %s has negative value %s' % (country_code, k, v))
+    if (obj.get('production', {}).get('unknown', None) is None and
+        obj.get('production', {}).get('coal', None) is None and
+        obj.get('production', {}).get('oil', None) is None and
+        country_code not in ['CH', 'NO', 'AUS-TAS']):
+            raise Exception("Coal or oil or unknown production value is "
+                            "required for %s" % (country_code))
+    for k, v in obj['production'].items():
+        if v is None:
+            continue
+        if v < 0:
+            raise ValueError('%s: key %s has negative value %s' %
+                             (country_code, k, v))

--- a/parsers/statnett.py
+++ b/parsers/statnett.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -82,22 +84,22 @@ def fetch_production(country_code='SE', session=None):
     data = {
         'countryCode': country_code,
         'production': {
-            'nuclear': float(filter(
+            'nuclear': float(list(filter(
                 lambda x: x['titleTranslationId'] == 'ProductionConsumption.%s%sDesc' % ('Nuclear', country_code),
-                obj['NuclearData'])[0]['value'].replace(u'\xa0', '')),
-            'hydro': float(filter(
+                obj['NuclearData']))[0]['value'].replace(u'\xa0', '')),
+            'hydro': float(list(filter(
                 lambda x: x['titleTranslationId'] == 'ProductionConsumption.%s%sDesc' % ('Hydro', country_code),
-                obj['HydroData'])[0]['value'].replace(u'\xa0', '')),
-            'wind': float(filter(
+                obj['HydroData']))[0]['value'].replace(u'\xa0', '')),
+            'wind': float(list(filter(
                 lambda x: x['titleTranslationId'] == 'ProductionConsumption.%s%sDesc' % ('Wind', country_code),
-                obj['WindData'])[0]['value'].replace(u'\xa0', '')),
+                obj['WindData']))[0]['value'].replace(u'\xa0', '')),
             'unknown':
-                float(filter(
+                float(list(filter(
                     lambda x: x['titleTranslationId'] == 'ProductionConsumption.%s%sDesc' % ('Thermal', country_code),
-                    obj['ThermalData'])[0]['value'].replace(u'\xa0', '')) +
-                float(filter(
+                    obj['ThermalData']))[0]['value'].replace(u'\xa0', '')) +
+                float(list(filter(
                     lambda x: x['titleTranslationId'] == 'ProductionConsumption.%s%sDesc' % ('NotSpecified', country_code),
-                    obj['NotSpecifiedData'])[0]['value'].replace(u'\xa0', '')),
+                    obj['NotSpecifiedData']))[0]['value'].replace(u'\xa0', '')),
         },
         'storage': {},
         'source': 'driftsdata.stattnet.no',
@@ -114,9 +116,9 @@ def fetch_exchange_by_bidding_zone(bidding_zone1='DK1', bidding_zone2='NO2', ses
     response = r.get(url)
     obj = response.json()
 
-    exchange = filter(
+    exchange = list(filter(
         lambda x: set([x['OutAreaElspotId'], x['InAreaElspotId']]) == set([bidding_zone_a, bidding_zone_b]),
-        obj)[0]
+        obj))[0]
 
     return {
         'sortedBiddingZones': '->'.join([bidding_zone_a, bidding_zone_b]),
@@ -130,10 +132,11 @@ def _fetch_exchanges_from_sorted_bidding_zones(sorted_bidding_zones, session=Non
     return fetch_exchange_by_bidding_zone(zones[0], zones[1], session)
 
 def _sum_of_exchanges(exchanges):
+    exchange_list = list(exchanges)
     return {
-        'netFlow': sum(map(lambda e: e['netFlow'], exchanges)),
-        'datetime': exchanges[0]['datetime'],
-        'source': exchanges[0]['source']
+        'netFlow': sum(e['netFlow'] for e in exchanges),
+        'datetime': exchange_list[0]['datetime'],
+        'source': exchange_list[0]['source']
     }
 
 def fetch_exchange(country_code1='DK', country_code2='NO', session=None):
@@ -149,7 +152,7 @@ def fetch_exchange(country_code1='DK', country_code2='NO', session=None):
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print 'fetch_production(SE) ->'
-    print fetch_production('SE')
-    print 'fetch_exchange(NO, SE) ->'
-    print fetch_exchange('NO', 'SE')
+    print('fetch_production(SE) ->')
+    print(fetch_production('SE'))
+    print('fetch_exchange(NO, SE) ->')
+    print(fetch_exchange('NO', 'SE'))

--- a/parsers/statnett.py
+++ b/parsers/statnett.py
@@ -1,5 +1,4 @@
-from __future__ import print_function
-
+#!/usr/bin/env python3
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -148,6 +147,7 @@ def fetch_exchange(country_code1='DK', country_code2='NO', session=None):
     data['sortedCountryCodes'] = '->'.join(sorted([country_code1, country_code2]))
 
     return data
+
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""

--- a/parsers/test/lib/test_IN.py
+++ b/parsers/test/lib/test_IN.py
@@ -12,27 +12,27 @@ class TestIndia(unittest.TestCase):
         html = BeautifulSoup(html_span, 'html.parser')
         india_date_time = IN.read_datetime_from_span_id(html, 'lbldate', 'D/M/YYYY h:mm:ss A')
         self.assertIsNotNone(india_date_time)
-        self.assertEquals(india_date_time.isoformat(), '2017-04-09T17:17:00+05:30')
+        self.assertEqual(india_date_time.isoformat(), '2017-04-09T17:17:00+05:30')
 
         html_span = '<p><span id="lblPowerStatusDate">04-09-2017 17:13</span></p>'
         html = BeautifulSoup(html_span, 'html.parser')
         india_date_time = IN.read_datetime_from_span_id(html, 'lblPowerStatusDate', 'DD-MM-YYYY HH:mm')
         self.assertIsNotNone(india_date_time)
-        self.assertEquals(india_date_time.isoformat(), '2017-09-04T17:13:00+05:30')
+        self.assertEqual(india_date_time.isoformat(), '2017-09-04T17:13:00+05:30')
 
     def test_read_text_from_span_id(self):
         html_span = '<span id="lblcgs" style="font-weight:bold;">2998</span>'
         html = BeautifulSoup(html_span, 'html.parser')
         cgs_value = IN.read_text_from_span_id(html, 'lblcgs')
         self.assertIsNotNone(cgs_value)
-        self.assertEquals(cgs_value, "2998")
+        self.assertEqual(cgs_value, "2998")
 
     def test_read_value_from_span_id(self):
         html_span = '<span id="lblcgs" style="font-weight:bold;">2998</span>'
         html = BeautifulSoup(html_span, 'html.parser')
         cgs_value = IN.read_value_from_span_id(html, 'lblcgs')
         self.assertIsNotNone(cgs_value)
-        self.assertEquals(cgs_value, 2998.0)
+        self.assertEqual(cgs_value, 2998.0)
 
     def test_read_india_datetime_with_only_time(self):
         mock_now = get('2017-11-01T19:05:01+00:00')
@@ -40,14 +40,14 @@ class TestIndia(unittest.TestCase):
         time_format = 'HH:mm:ss'
         india_date_time = IN.read_datetime_with_only_time(time_string, time_format, mock_now)
         self.assertIsNotNone(india_date_time)
-        self.assertEquals(india_date_time.isoformat(), '2017-11-02T01:05:01+05:30')
+        self.assertEqual(india_date_time.isoformat(), '2017-11-02T01:05:01+05:30')
 
         mock_now = get('2017-11-02T01:05:01+00:00')
         time_string = '06:35:01'
         time_format = 'HH:mm:ss'
         india_date_time = IN.read_datetime_with_only_time(time_string, time_format, mock_now)
         self.assertIsNotNone(india_date_time)
-        self.assertEquals(india_date_time.isoformat(), '2017-11-02T06:35:01+05:30')
+        self.assertEqual(india_date_time.isoformat(), '2017-11-02T06:35:01+05:30')
 
 
 if __name__ == '__main__':

--- a/parsers/test/lib/test_countrycode.py
+++ b/parsers/test/lib/test_countrycode.py
@@ -16,13 +16,13 @@ class TestCountyCode(unittest.TestCase):
             countrycode.assert_country_code('ES', 'ES-IB')
         except ParserException as ex:
             self.assertIsInstance(ex, ParserException)
-            self.assertEquals(str(ex), "ES Parser (ES): Country_code expected ES-IB, is ES")
+            self.assertEqual(str(ex), "ES Parser (ES): Country_code expected ES-IB, is ES")
 
         try:
             countrycode.assert_country_code('ES', 'ES-IB', 'ESIOS')
         except ParserException as ex:
             self.assertIsInstance(ex, ParserException)
-            self.assertEquals(str(ex), "ESIOS Parser (ES): Country_code expected ES-IB, is ES")
+            self.assertEqual(str(ex), "ESIOS Parser (ES): Country_code expected ES-IB, is ES")
 
 
 if __name__ == '__main__':

--- a/parsers/test/lib/test_exceptions.py
+++ b/parsers/test/lib/test_exceptions.py
@@ -8,12 +8,12 @@ class TestParserException(unittest.TestCase):
     def test_instance(self):
         exception = ParserException('ESIOS', "Parser exception")
         self.assertIsInstance(exception, ParserException)
-        self.assertEquals(str(exception), 'ESIOS Parser: Parser exception')
+        self.assertEqual(str(exception), 'ESIOS Parser: Parser exception')
 
     def test_instance_with_country_code(self):
         exception = ParserException('ESIOS', "Parser exception", "ES")
         self.assertIsInstance(exception, ParserException)
-        self.assertEquals(str(exception), 'ESIOS Parser (ES): Parser exception')
+        self.assertEqual(str(exception), 'ESIOS Parser (ES): Parser exception')
 
 
 if __name__ == '__main__':

--- a/parsers/test/test_ESIOS.py
+++ b/parsers/test/test_ESIOS.py
@@ -1,10 +1,11 @@
 import unittest
-
-from requests import Session
-from requests_mock import Adapter, ANY
-from pkg_resources import resource_string
 from json import loads
+
+from pkg_resources import resource_string
+from requests import Session
+
 from parsers import ESIOS
+from requests_mock import ANY, Adapter
 
 
 class TestESIOS(unittest.TestCase):
@@ -27,6 +28,7 @@ class TestESIOS(unittest.TestCase):
                 self.assertIsNotNone(data['netFlow'])
         except Exception as ex:
             self.fail(ex.message)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/parsers/test/test_ESIOS.py
+++ b/parsers/test/test_ESIOS.py
@@ -16,7 +16,7 @@ class TestESIOS(unittest.TestCase):
 
     def test_fetch_exchange(self):
         json_data = resource_string("parsers.test.mocks", "ESIOS_ES_MA.json")
-        self.adapter.register_uri(ANY, ANY, json=loads(json_data))
+        self.adapter.register_uri(ANY, ANY, json=loads(json_data.decode("utf-8")))
         try:
             data_list = ESIOS.fetch_exchange('ES', 'MA', self.session, 'ESIOS_MOCK_TOKEN')
             self.assertIsNotNone(data_list)

--- a/parsers/test/test_IN_AP.py
+++ b/parsers/test/test_IN_AP.py
@@ -12,7 +12,7 @@ class Test_IN_AP(unittest.TestCase):
         self.adapter = Adapter()
         self.session.mount('http://', self.adapter)
         response_text = resource_string("parsers.test.mocks", "IN_AP.html")
-        self.adapter.register_uri(ANY, ANY, text=response_text)
+        self.adapter.register_uri(ANY, ANY, text=str(response_text))
 
     def test_fetch_production(self):
         try:

--- a/parsers/test/test_IN_PB.py
+++ b/parsers/test/test_IN_PB.py
@@ -27,7 +27,7 @@ class TestINPB(unittest.TestCase):
             self.assertIsNotNone(data['datetime'])
             expected = get(datetime(2017, 9, 6, 14, 38, 29), 'Asia/Kolkata').datetime
             date_time = data['datetime']
-            self.assertEquals(date_time, expected)
+            self.assertEqual(date_time, expected)
             self.assertIsNotNone(data['consumption'])
             self.assertEqual(data['consumption'], 7451.0)
         except Exception as ex:
@@ -53,17 +53,17 @@ class TestINPB(unittest.TestCase):
         text ='<b><font size="4">&nbsp;09/06/2017</b></font>'
         date_text = IN_PB.read_text_by_regex('(\d+/\d+/\d+)', text)
         expected = "09/06/2017"
-        self.assertEquals(date_text, expected)
+        self.assertEqual(date_text, expected)
 
         text = '<b>Time :&nbsp;14:38:29</b>'
         date_text = IN_PB.read_text_by_regex('(\d+:\d+:\d+)', text)
         expected = "14:38:29"
-        self.assertEquals(date_text, expected)
+        self.assertEqual(date_text, expected)
 
         text = '<b>&nbsp;&nbsp; Last Updated at&nbsp; 13:33:59</b><br>'
         date_text = IN_PB.read_text_by_regex('(\d+:\d+:\d+)', text)
         expected = "13:33:59"
-        self.assertEquals(date_text, expected)
+        self.assertEqual(date_text, expected)
 
     def test_date_time_strings_to_kolkata_date(self):
         date_text = "09/06/2017"
@@ -73,7 +73,7 @@ class TestINPB(unittest.TestCase):
         date_time = IN_PB.date_time_strings_to_kolkata_date(date_text, date_format, time_text, time_format)
         self.assertIsNotNone(date_time)
         expected = get(datetime(2017, 6, 9, 13, 33, 59), 'Asia/Kolkata')
-        self.assertEquals(date_time, expected)
+        self.assertEqual(date_time, expected)
 
 
 if __name__ == '__main__':

--- a/parsers/test/test_quality.py
+++ b/parsers/test/test_quality.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 
 """Tests for quality.py."""
-
 import unittest
 from parsers.lib.quality import validate_consumption, validate_exchange, validate_production
 from mocks.quality_check import *


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There might be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
