### PR TITLE
Fix mockserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   mockserver:
     build: mockserver
-    ports: ['9000:9000']
+    ports: ['9000:8000']
     volumes:
       - './mockserver/public:/home/public'
       - './mockserver/server.py:/home/server.py'

--- a/mockserver/Dockerfile
+++ b/mockserver/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.6
 WORKDIR /home
-EXPOSE 9000
+EXPOSE 8000
 ADD server.py server.py
-CMD cd public && python ../server.py 9000
+CMD cd public && python ../server.py

--- a/mockserver/server.py
+++ b/mockserver/server.py
@@ -2,7 +2,7 @@
 
 # Usage: python __file__.py <port>
 
-from SimpleHTTPServer import SimpleHTTPRequestHandler, BaseHTTPServer
+from http.server import SimpleHTTPRequestHandler, HTTPServer, test
 
 class CORSRequestHandler(SimpleHTTPRequestHandler):
     def do_OPTIONS(self):
@@ -15,4 +15,4 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
         SimpleHTTPRequestHandler.end_headers(self)
 
 if __name__ == '__main__':
-    BaseHTTPServer.test(CORSRequestHandler, BaseHTTPServer.HTTPServer)
+    test(CORSRequestHandler, HTTPServer)


### PR DESCRIPTION
Fix #979 
Run `docker-compose build` first to make sure all dependencies are up to date.