### PR TITLE
Fix KeyError in Bolivia

### DIFF
--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -65,7 +65,10 @@ def fetch_hourly_production(country_code, obj, hour, date):
         hour = 24
     # Fill production types
     for i_type in MAP_GENERATION.keys():
-        data['production'][i_type] = obj[MAP_GENERATION[i_type]][obj.hour == hour].iloc[0]
+        try:
+            data['production'][i_type] = obj[MAP_GENERATION[i_type]][obj.hour == hour].iloc[0]
+        except KeyError as e:
+            data['production'][i_type] = None
 
     return data
 
@@ -92,6 +95,7 @@ def fetch_production(country_code='BO', session=None):
     data_temp = fetch_hourly_production(country_code, obj, 0, formatted_date)
     data[0] = data_temp
 
+    # TODO This creates an identical dataframe for every hour. We only need one for all hours.
     # Fill data for the other hours until actual hour
     if actual_hour > 1:
         url = url_init + formatted_date
@@ -142,6 +146,7 @@ def fetch_generation_forecast(country_code='BO', session=None):
     response = r.get(url)
     obj = webparser(response)
 
+    # TODO This creates an identical dataframe for every hour. We only need one for all hours.
     for h in range(1, 25):
         data_temp = fetch_hourly_generation_forecast('BO', obj, h, formatted_date)
         data[h - 1] = data_temp

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -68,7 +68,8 @@ def fetch_hourly_production(country_code, obj, hour, date):
         try:
             data['production'][i_type] = obj[MAP_GENERATION[i_type]][obj.hour == hour].iloc[0]
         except KeyError as e:
-            data['production'][i_type] = None
+            data['production'] = None
+            break
 
     return data
 
@@ -107,7 +108,12 @@ def fetch_production(country_code='BO', session=None):
             data_temp = fetch_hourly_production(country_code, obj, h, formatted_date)
             data[h] = data_temp
 
-    return data
+    valid_data = []
+    for datapoint in data:
+        if datapoint['production'] is not None:
+            valid_data.append(datapoint)
+            
+    return valid_data
 
 
 def fetch_hourly_generation_forecast(country_code, obj, hour, date):


### PR DESCRIPTION
This should stop Bolivia losing all data when there is no wind data available. There is more work to be done in making the parser get only 1 dataframe for hourly data rather than creating up to 23 identical ones. But I'd like to make sure this fix is working ok before doing that.

ref #984 