### PR TITLE
Add CAISO RES-capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1750,6 +1750,13 @@
     "timezone": null
   },
   "US-CA": {
+    "capacity": {
+      "battery": 136,
+      "biomass": 997,
+      "geothermal": 1799,
+      "solar": 11172,
+      "wind": 6269
+    },
     "contributors": [
       "https://github.com/7hibault",
       "https://github.com/corradio",


### PR DESCRIPTION
These numbers represent CAISO region (~80% of California).
See http://www.caiso.com/informed/Pages/CleanGrid/default.aspx

ref #1047 