### PR TITLE
fix typo for battery capacity for CAISO

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1751,7 +1751,7 @@
   },
   "US-CA": {
     "capacity": {
-      "battery": 136,
+      "battery storage": 136,
       "biomass": 997,
       "geothermal": 1799,
       "solar": 11172,


### PR DESCRIPTION
I only entered "battery" instead of "battery storage" to CAISO capacity. Fixed it - I am sorry!