### PR TITLE
Rename “between countries” to “between zones”

### DIFF
--- a/web/locales/ar.json
+++ b/web/locales/ar.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "نأخذ الكهرباء بعين الاعتبار",
         "importexport": "الواردات والصادرات",
-        "betweencountries": "بين الدول",
+        "betweenzones": "بين الدول",
 
         "thisproject": "هذا المشروع",
         "opensource": "مفتوح المصدر",

--- a/web/locales/da.json
+++ b/web/locales/da.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "Vi medtager",
         "importexport": "import og eksport af elektricitet",
-        "betweencountries": "mellem lande",
+        "betweenzones": "mellem lande",
 
         "thisproject": "Projektet er",
         "opensource": "Open Source",

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -7,7 +7,7 @@
         "wasemitted": "emittiert wurde, um sie zu produzieren",
         "takeinaccount": "Wir berücksichtigen den",
         "importexport": "Elektrizitätsaustausch",
-        "betweencountries": "zwischen verbundenen Staaten",
+        "betweenzones": "zwischen verbundenen Staaten",
         "thisproject": "Dieses Projekt ist",
         "opensource": "Open Source",
         "see": "siehe",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -7,7 +7,7 @@
         "wasemitted": "was emitted to produce it",
         "takeinaccount": "We take into account electricity",
         "importexport": "imports and exports",
-        "betweencountries": "between countries",
+        "betweenzones": "between zones",
         "thisproject": "This project is",
         "opensource": "Open Source",
         "see": "see",

--- a/web/locales/es.json
+++ b/web/locales/es.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "Tenemos en cuenta la electricidad",
         "importexport": "importada y exportada",
-        "betweencountries": "entre países",
+        "betweenzones": "entre países",
 
         "thisproject": "Este proyecto es",
         "opensource": "Código abierto",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -7,7 +7,7 @@
         "wasemitted": "a été émise pour la produire",
         "takeinaccount": "Elle prend en compte les",
         "importexport": "importations et exportations",
-        "betweencountries": "entre pays",
+        "betweenzones": "entre pays",
         "thisproject": "Ceci est un projet",
         "opensource": "Open Source",
         "see": "voir",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -7,7 +7,7 @@
         "wasemitted": "è stata emessa per produrla",
         "takeinaccount": "Seguendo le frecce vedrai quale elettricità",
         "importexport": "è importata ed esportata",
-        "betweencountries": "attraverso le nazioni",
+        "betweenzones": "attraverso le nazioni",
         "thisproject": "Questo progetto è",
         "opensource": "libero",
         "see": "Vedi",

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -7,7 +7,7 @@
         "wasemitted": "の生産",
         "takeinaccount": "電力の国の間の",
         "importexport": "供給",
-        "betweencountries": "は計算されています",
+        "betweenzones": "は計算されています",
         "thisproject": "このプロジェクトは",
         "opensource": "オープンソースです",
         "see": "",

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "We nemen de elektriciteit in beschouwing afkomstig van",
         "importexport": "invoer en uitvoer",
-        "betweencountries": "tussen landen",
+        "betweenzones": "tussen landen",
 
         "thisproject": "Dit project is",
         "opensource": "Open Source",

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "Bierzemy pod uwagę",
         "importexport": "import i eksport",
-        "betweencountries": "energii elektrycznej pomiędzy regionami",
+        "betweenzones": "energii elektrycznej pomiędzy regionami",
 
         "thisproject": "Ten projekt jest",
         "opensource": "Open Source",

--- a/web/locales/pt-br.json
+++ b/web/locales/pt-br.json
@@ -7,7 +7,7 @@
         "wasemitted": "foi emitido para produzi-la",
         "takeinaccount": "Nós levamos em consideração a eletridade",
         "importexport": "importada e exportada",
-        "betweencountries": "entre países",
+        "betweenzones": "entre países",
         "thisproject": "Este projeto é",
         "opensource": "código aberto",
         "see": "ver",

--- a/web/locales/sv.json
+++ b/web/locales/sv.json
@@ -7,7 +7,7 @@
         "wasemitted": "som släpptes ut för att producera den",
         "takeinaccount": "Vi tar hänsyn till",
         "importexport": "import och export",
-        "betweencountries": "av el mellan länder",
+        "betweenzones": "av el mellan länder",
         "thisproject": "Detta projekt har",
         "opensource": "öppen källkod",
         "see": "se",

--- a/web/locales/zh-cn.json
+++ b/web/locales/zh-cn.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "我们考虑到电力",
         "importexport": "汇入及汇出",
-        "betweencountries": "国家之间",
+        "betweenzones": "国家之间",
 
         "thisproject": "这个项目是",
         "opensource": "开源资料",

--- a/web/locales/zh-hk.json
+++ b/web/locales/zh-hk.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "我們考慮到電力",
         "importexport": "匯入及匯出",
-        "betweencountries": "國家之間",
+        "betweenzones": "國家之間",
 
         "thisproject": "這個項目是",
         "opensource": "開源資料",

--- a/web/locales/zh-tw.json
+++ b/web/locales/zh-tw.json
@@ -8,7 +8,7 @@
 
         "takeinaccount": "我們考慮到電力",
         "importexport": "匯入及匯出",
-        "betweencountries": "國家之間",
+        "betweenzones": "國家之間",
 
         "thisproject": "這個項目是",
         "opensource": "開源資料",

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -163,7 +163,7 @@ co2Sub = function(str) {
                                 <%- __('panel-initial-text.thisshowsrealtime') %> <span style="color: lightgray"><%- __('panel-initial-text.whereelectricitycomesfrom') %></span> <%- __('panel-initial-text.and') %> <span style="color: lightgray"><%- co2Sub(__('panel-initial-text.howmuchco2')) %></span> <%- __('panel-initial-text.wasemitted') %>.
                             </p>
                             <p>
-                                <%- __('panel-initial-text.takeinaccount') %> <span style="color: lightgray"><%- __('panel-initial-text.importexport') %></span><span class="large-screen-visible" style="white-space: nowrap;"> <img src="images/arrow-400-animated-0.gif" style="width: 1em; transform: rotate(90deg); transform-origin: 0; margin-left: 0.9em;" /></span> <%- __('panel-initial-text.betweencountries') %>.
+                                <%- __('panel-initial-text.takeinaccount') %> <span style="color: lightgray"><%- __('panel-initial-text.importexport') %></span><span class="large-screen-visible" style="white-space: nowrap;"> <img src="images/arrow-400-animated-0.gif" style="width: 1em; transform: rotate(90deg); transform-origin: 0; margin-left: 0.9em;" /></span> <%- __('panel-initial-text.betweenzones') %>.
                             </p>
                             <p class="large-screen-visible">
                                 <span style="font-size: 1.2em; color: white;"><i><%- __('panel-initial-text.tip') %> ⟶</i></span>


### PR DESCRIPTION
Next step will be to re-translate the new string, currently all foreign languages are still “between countries”.