### PR TITLE
Quick fix for Crimea

### DIFF
--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -350,7 +350,7 @@
         "RE": "Réunion",
         "RO": "Romania",
         "RS": "Serbia",
-        "RU": "Russia",
+        "RU": "Russia & Crimea",
         "RU-EU": "Russia",
         "RU-AS": "Russia",
         "RU-KGD": "Russia (Kaliningrad)",


### PR DESCRIPTION
Calling the zone "Russia & Crimea" is a possible temporary solution. 
Crimea is included in RU market data that is currently used and is exclusively connected to the RU electricity grid at the moment, so this is the "technical quick fix" for the common _bidding zone_ until parsers are adjusted/ready.
Ref #1122 