### PR TITLE
Fix Bolivia validation checks

### DIFF
--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -144,9 +144,13 @@ def fetch_production(country_code='BO', session=None):
     #    updates ~5mins after the hour so condition 2 will pass.
     valid_data = []
     for datapoint in data:
-        if all([datapoint['production'] is not None,
-                now.datetime > datapoint['datetime'],
-                sum(datapoint['production'].values()) != 0.0]):
+        if datapoint['production'] is None:
+            continue
+        elif now.datetime < datapoint['datetime']:
+            continue
+        elif sum(datapoint['production'].values()) == 0.0:
+            continue
+        else:
             valid_data.append(datapoint)
 
     return valid_data


### PR DESCRIPTION
The all() check evaluates every statement for True/False, but sometimes production is deliberately set to None in the preceding function causing an AttributeError when the final check happens. This fix makes each check independent and explicit so any None's will be caught before reaching the final check.

fixes #1145