### PR TITLE
Fix Moldova session handling

### DIFF
--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -25,9 +25,10 @@ def get_data(session=None):
 
     s = session or requests.Session()
 
+    #In order for the data url to return data, cookies from the display url must be obtained then reused.
+    response = s.get(display_url)
     data_response = s.get(data_url)
     raw_data = data_response.text
-
     data = [float(i) for i in raw_data.split(',')]
 
     return data


### PR DESCRIPTION
This was removed for some reason. With the MD parser you must visit the display page first then the data url because a valid session is required to access the data.

fixes #1195 