### PR TITLE
imports to CAISO

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -1322,6 +1322,16 @@
     },
     "rotation": 90
   },
+  "US->US-CA": {
+    "lonlat": [
+      -115.846,
+      35.962
+    ],
+    "parsers": {
+      "exchange": "US_CA.fetch_exchange"
+    },
+    "rotation": -135
+  },
   "US-MISO->US-PJM": {
     "lonlat": [
       -84.803,


### PR DESCRIPTION
This is a quick-and-dirty implementation of #959. It's not split out by state, and absent carbon intensities of the import source it won't give any more accurate information, but should give a slightly more _informative_ view. California continuously imported between 5 and 10 GW yesterday and the data might be particularly useful to illustrate how imports compensate for the considerable solar production.

cc @alixunderplatz, you did some research on the grid neighbours, that will still be useful, but note this placeholder until we can crack all the other imports.