### PR TITLE
Map Dual Fuel in NY ISO to natural gas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
   - CAISO: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
   - MISO: [MISO](https://www.misoenergy.org/about/media-center/corporate-fact-sheet/)
+  - NYISO: [NYISO Gold Book](https://home.nyiso.com/wp-content/uploads/2017/12/2017_Gold-Book.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2017.ashx?la=en)
 &nbsp;</details>
 

--- a/config/zones.json
+++ b/config/zones.json
@@ -1967,6 +1967,15 @@
     "timezone": null
   },
   "US-NY": {
+    "_comment": "hydro incl. 1407 MW pumped storage",
+    "capacity": {
+      "gas": 22117,
+      "coal": 1011,
+      "oil": 2499,
+      "nuclear": 5375,
+      "hydro": 5658,
+      "wind": 1740
+    },
     "contributors": [
       "https://github.com/systemcatch"
     ],

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -10,7 +10,7 @@ import arrow
 import pandas as pd
 
 mapping = {
-    'Dual Fuel': 'unknown',
+    'Dual Fuel': 'gas',
     'Natural Gas': 'gas',
     'Nuclear': 'nuclear',
     'Other Fossil Fuels': 'unknown',

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -9,6 +9,13 @@ from urllib.error import HTTPError
 import arrow
 import pandas as pd
 
+# Dual Fuel systems can run either Natural Gas or Oil, they represent
+# significantly more capacity in NY State than plants that can only
+# burn Natural Gas. When looking up fuel usage for NY in 2016 in
+# https://www.eia.gov/electricity/data/state/annual_generation_state.xls
+# 100 times more energy came from NG than Oil. That means Oil
+# consumption in the Dual Fuel systems is roughly ~1%, and to a first
+# approximation it's just Natural Gas.
 mapping = {
     'Dual Fuel': 'gas',
     'Natural Gas': 'gas',


### PR DESCRIPTION
NY ISO has a lot of plants that are Dual Fuel plants, which mostly
burn natural gas, but have the ability to burn other liquid petroleum
as a local reserve to shave off natural gas demand when its needed for
heating. On any given day in NYISO these Dual Fuel plants end up
running about as much as pure Natural Gas plants.

However, looking at 2016 (last year available) numbers for aggregate
fuel usage, oil burned in the state accounts for 1% of the MW as
natural gas.

* Net Generation by State by Type of Producer by Energy Source
  (EIA-906, EIA-920, and EIA-923)
  (https://www.eia.gov/electricity/data/state/annual_generation_state.xls)

The NY Numbers for 2016 on power generation are (power in MWh)
2016	NY	Total Electric Power Industry	Total	134,417,107
2016	NY	Total Electric Power Industry	Coal	1,770,238
2016	NY	Total Electric Power Industry	Pumped Storage	-470,932
2016	NY	Total Electric Power Industry	Hydroelectric Conventional	26,888,234
2016	NY	Total Electric Power Industry	Natural Gas	56,793,336
2016	NY	Total Electric Power Industry	Nuclear	41,570,990
2016	NY	Total Electric Power Industry	Other Gases	0
2016	NY	Total Electric Power Industry	Other	898,989
2016	NY	Total Electric Power Industry	Petroleum	642,952
2016	NY	Total Electric Power Industry	Solar Thermal and Photovoltaic	139,611
2016	NY	Total Electric Power Industry	Other Biomass	1,604,650
2016	NY	Total Electric Power Industry	Wind	3,940,180
2016	NY	Total Electric Power Industry	Wood and Wood Derived Fuels	638,859

Mapping Dual Fuel completely into natural gas might be slightly
undercounting, however given that other fossil fuels and other
renewable are being overcounted, this probably comes out in the
wash. It is definitely more accurate than accounting Dual Fuel systems
to 700g/kWh in the current model.

Fixes #1227