### PR TITLE
hardcode export intensities for AZ, CA-NB, ZA, ZM

### DIFF
--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -96,12 +96,41 @@ var countryCo2eqFootprint = {
 };
 
 var defaultExportCo2eqFootprint = {
+    'AZ': {
+        carbonIntensity: 470,
+        renewableRatio: 0.07,
+        fossilFuelRatio: 0.92,
+        source: 'IEA yearly data for 2015',
+        url: 'https://www.iea.org/statistics/statisticssearch/report/?country=AZERBAIJAN&product=electricityandheat&year=2015'
+    },
+    'CA-NB': {
+        carbonIntensity: 300,
+        renewableRatio: 0.27,
+        fossilFuelRatio: 0.40,
+        source: 'Canada NEB yearly data for 2016',
+        url: 'https://www.neb-one.gc.ca/nrg/ntgrtd/mrkt/nrgsstmprfls/nb-eng.html'
+    },
     'CA-QC': {
         carbonIntensity: 30,
         renewableRatio: 0.98,
         fossilFuelRatio: 1 - 0.98,
         source: 'StatCan CANSIM Table 127-0002 for 2011-2015',
-        comment: 'see http://piorkowski.ca/rev/2017/06/canadian-electricity-co2-intensities/ and https://gist.github.com/jarek/bb06a7e1c5d9005b29c63562ac812ad7'
+        comment: 'see http://piorkowski.ca/rev/2017/06/canadian-electricity-co2-intensities/ and https://gist.github.com/jarek/bb06a7e1c5d9005b29c63562ac812ad7',
+        comment2: 'not using NEB data here since the NEB resolution is 1% which makes a difference at these scales'
+    },
+    'ZA': {
+        carbonIntensity: 750,
+        renewableRatio: 0.03,
+        fossilFuelRatio: 0.92,
+        source: 'IEA yearly data for 2015',
+        url: 'https://www.iea.org/statistics/statisticssearch/report/?country=SOUTHAFRIC&product=electricityandheat&year=2015'
+    },
+    'ZM': {
+        carbonIntensity: 50,
+        renewableRatio: 0.97,
+        fossilFuelRatio: 0.03,
+        source: 'IEA yearly data for 2015',
+        url: 'https://www.iea.org/statistics/statisticssearch/report/?country=ZAMBIA&product=electricityandheat&year=2015'
     }
 }
 

--- a/config/zones.json
+++ b/config/zones.json
@@ -1431,7 +1431,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/jarek"
+      "https://github.com/jarek",
+      "https://github.com/alixunderplatz"
     ],
     "parsers": {
       "production": "NA.fetch_production"


### PR DESCRIPTION
re https://github.com/tmrowco/electricitymap/issues/563, cc @alixunderplatz @systemcatch 

This provides intensities for zones which are export-heavy and make up a significant amount of supply in at least one other zone for which we have real-time information.

Intensities are calculated by Electricity Map's fuel intensities and ratio of the fuels in the yearly generation. The values are rounded to nearest 10 since it's a rough estimate anyway.

CA-NB is a little conservative since it doesn't take NB's imports from QC into account, but I'd suggest better to overestimate than underestimate...

RIP PEI's days as nonstop climate leader on Electricity Map