### PR TITLE
Increased size of zoom and layer toggle buttons

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -500,7 +500,7 @@ body {
 .layer-buttons-container {
     position: absolute;
     right: 10px;
-    top: 80px;
+    top: 90px;
     display: flex;
     flex-direction: column;
 }
@@ -509,12 +509,12 @@ body {
     background-color: #fff;
     border-radius: 7px;
     box-shadow: 0px 0px 0px 2px rgba(0,0,0,0.1);
-    width: 30px;
-    height: 30px;
+    width: 35px;
+    height: 35px;
     margin-bottom: 10px;
     background-repeat: no-repeat;
     background-position: center;
-    background-size: 57% 57%;
+    background-size: 58% 57%;
     border: none;
     outline: none;
     box-sizing: border-box;
@@ -541,6 +541,11 @@ body {
     background-image: url(../images/weather/sun_active.svg);
 }
 
+/* override mapbox styling */
+.mapboxgl-ctrl-group > button {
+    width: 35px !important;
+    height: 35px !important;
+}
 
 
 /* ** LEGEND ** */
@@ -949,3 +954,4 @@ sub {
         margin-left: 80px;
     }
 }
+


### PR DESCRIPTION
Fixes #1205 

I've increased the buttons sizes by 5px/5px. Hopefully this is enough to make them easier to tap on mobile. Any bigger, however, and I think they will take up too much space on small screens. Let me know what you think. 

Desktop:
![image](https://user-images.githubusercontent.com/7040743/37821087-f0d31ebe-2e82-11e8-96fa-31ba43b72b31.png)

Mobile:
![image](https://user-images.githubusercontent.com/7040743/37821053-d59227f8-2e82-11e8-97dc-1e65fa8f0000.png)
