### PR TITLE
SG: don't fail when unable to OCR

### DIFF
--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -87,7 +87,9 @@ def get_solar(session, logger):
 
     # Need to be sure we don't get old data if image stops updating.
     if diff.seconds > 3600:
-        print('Singapore solar data is too old to use.')
+        msg = ('Singapore solar data is too old to use, '
+               'parsed data timestamp was {}.').format(solar_dt)
+        logger.warning(msg, extra={'key': 'SG'})
         return None
 
     # At night format changes from 0.00 to 0
@@ -95,16 +97,18 @@ def get_solar(session, logger):
     # This try/except will make sure no invalid data is returned.
     try:
         solar = float(val)
-    except ValueError as err:
+    except ValueError:
         if len(val) == 1 and 'O' in val:
             solar = 0.0
         else:
-            print("Singapore solar data is unreadable - got {}.".format(val))
-            solar = None
+            msg = "Singapore solar data is unreadable - got {}.".format(val)
+            logger.warning(msg, extra={'key': 'SG'})
+            return None
     else:
         if solar > 200.0:
-            print("Singapore solar generation is way over capacity - got {}".format(val))
-            solar = None
+            msg = "Solar generation is way over capacity - got {}".format(val)
+            logger.warning(msg, extra={'key': 'SG'})
+            return None
 
     return solar
 

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -219,16 +219,12 @@ def fetch_production(zone_key='SG', session=None, target_datetime=None,
         'hydro': 0
     })
 
-    source = 'emcsg.com'
-    if generation_by_type['solar']:
-        source += ', ema.gov.sg'
-
     return {
         'datetime': sg_data_to_datetime(data),
         'zoneKey': zone_key,
         'production': generation_by_type,
         'storage': {},  # there is no known electricity storage in Singapore
-        'source': source
+        'source': 'emcsg.com, ema.gov.sg'
     }
 
 


### PR DESCRIPTION
Solar production is a very small part of Singapore electricity, so when it can't be retrieved, just log warning and move on.

Add the OCR'd text to log message to possibly aid debugging.

Currently the image is stuck on data from ~12 hours ago. The parser has code to discard too old data, but unfortunately the time 11:44 confuses terract, which reads it as `2018-03-31 1 1 :44`. Maybe the regexp could be improved to handle that, but in meanwhile, fall through and log better.