### PR TITLE
update NL 'unknown' carbon intensity

### DIFF
--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -77,6 +77,9 @@ var countryCo2eqFootprint = {
     'FI': function (productionMode) {
         return (productionMode == 'unknown' || productionMode == 'other') ? {value: 700, source: null} : null;
     },
+    'NL': function (productionMode) {
+        return (productionMode == 'unknown' || productionMode == 'other') ? {value: 556, source: 'assumes 54% gas, 33% coal, 5% biomass, 4% nuclear, 2% solar'} : null;
+    },  // Source: Derived from 2017 annual average: coal  30.0%, co-generation(gas)  19.0%, gas 28.0%, coke-oven-gas 5.0%, nuclear 4.0%, Wind  7.7%, biomass (waste) 4.90%, solar 1.40%, accoring to http://en-tran-ce.org/newsletter-renewable-energy-in-the-netherlands/
     'NO': function (productionMode) {
         if (productionMode == 'hydro') {
             // Source: Ostford Research (2015) "The inventory and life cycle data for Norwegian hydroelectricity"


### PR DESCRIPTION
2017 annual share of production in NL was coal  30.0%, co-generation(gas)  19.0%, gas 28.0%, coke-oven-gas 5.0%, nuclear 4.0%, Wind  7.7%, biomass (waste) 4.90%, solar 1.40%, accoring to http://en-tran-ce.org/newsletter-renewable-energy-in-the-netherlands/

Removing "wind" to get our "unknown" category, and considering as a first approximation all gas-based power plant emits IPCC's median carbon intensity for gas (490gCO2eq/kWh), the resulting value for unkwown is 556gCO2eq/kWh