### PR TITLE
Fixed zone details view for non-chrome browsers

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -973,7 +973,7 @@ function routeToPage(pageName, state) {
   // Hide all panels - we will show only the ones we need
   d3.selectAll('.left-panel > div').style('display', 'none');
   d3.selectAll('.left-panel .left-panel-social').style('display', undefined);
-  d3.selectAll(`.left-panel .left-panel-zone-list`).style('display', undefined);
+  d3.selectAll('.left-panel .left-panel-zone-list').style('display', (pageName !== 'country' ) ? undefined : 'none');
 
   // Replace left panel by country view (large screen only)
   d3.selectAll('.left-panel .left-panel-info')


### PR DESCRIPTION
Fixed issue with the zone details view (shown when clicking on a zone) showing partially the zone list on non-chrome browsers.