### PR TITLE
allow up to 2 hours for Namibian data

### DIFF
--- a/parsers/NA.py
+++ b/parsers/NA.py
@@ -75,7 +75,9 @@ def check_timestamp(session=None, logger=None):
     diff = current_time - data_time
 
     # Need to be sure we don't get old data if image stops updating.
-    if diff.seconds > 3600:
+    # In April 2018, timestamp is regularly just over an hour old.
+    # We think it might be due to DST misconfiguration, so allow up to 2 hours.
+    if diff.seconds > 7200:
         raise ValueError('Namibia scada data is too old to use, data is {} hours old.'.format(diff.seconds/3600))
 
 


### PR DESCRIPTION
As noticed by @systemcatch :

> There's lots of points that are just over 1 hour old. However Namibia stopped following DST in 2018, but maybe the scada dashboard hasn't been altered to reflect that.