### PR TITLE
Added tooltips to wind and solar layer toggle buttons

### DIFF
--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -71,7 +71,11 @@
         "carbonintensityexport": "Carbon intensity of export",
         "ofinstalled": "of installed capacity",
         "utilizing": "utilizing",
-        "withcarbonintensity": "with a carbon intensity of"
+        "withcarbonintensity": "with a carbon intensity of",
+        "showWindLayer": "Show wind layer",
+        "hideWindLayer": "Hide wind layer",
+        "showSolarLayer": "Show solar layer",
+        "hideSolarLayer": "Hide solar layer"
     },
     "misc": {
         "maintitle": "Live CO2 emissions of electricity consumption",

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -690,12 +690,31 @@ function toggleWind() {
 }
 d3.select('.wind-button').on('click', toggleWind);
 
+const windLayerButtonTooltip = d3.select('#wind-layer-button-tooltip');
+
+d3.select('.wind-button').on('mouseover', () => {
+  windLayerButtonTooltip.classed('hidden', false);
+});
+d3.select('.wind-button').on('mouseout', () => {
+  windLayerButtonTooltip.classed('hidden', true);
+});
+
+
 // Solar
 function toggleSolar() {
   if (typeof solarLayer === 'undefined') { return; }
   dispatchApplication('solarEnabled', !getState().application.solarEnabled);
 }
 d3.select('.solar-button').on('click', toggleSolar);
+
+const solarLayerButtonTooltip = d3.select('#solar-layer-button-tooltip');
+
+d3.select('.solar-button').on('mouseover', () => {
+  solarLayerButtonTooltip.classed('hidden', false);
+});
+d3.select('.solar-button').on('mouseout', () => {
+  solarLayerButtonTooltip.classed('hidden', true);
+});
 
 // Legend 
 function toggleLegend() {
@@ -1134,6 +1153,8 @@ observe(state => state.application.solarEnabled, (solarEnabled, state) => {
   d3.select('.solar-potential-legend').classed('visible', solarEnabled);
   Cookies.set('solarEnabled', solarEnabled);
 
+  solarLayerButtonTooltip.select('.tooltip-text').text(translation.translate(solarEnabled ? 'tooltips.hideSolarLayer' : 'tooltips.showSolarLayer'));
+
   const now = state.customDate ?
     moment(state.customDate) : (new Date()).getTime();
   if (solarEnabled && typeof solarLayer !== 'undefined') {
@@ -1151,6 +1172,8 @@ observe(state => state.application.solarEnabled, (solarEnabled, state) => {
 observe(state => state.application.windEnabled, (windEnabled, state) => {
   d3.selectAll('.wind-button').classed('active', windEnabled);
   d3.select('.wind-potential-legend').classed('visible', windEnabled);
+
+  windLayerButtonTooltip.select('.tooltip-text').text(translation.translate(windEnabled ? 'tooltips.hideWindLayer' : 'tooltips.showWindLayer'));
 
   Cookies.set('windEnabled', windEnabled);
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -566,6 +566,10 @@ body {
     flex-direction: column;
 }
 
+.layer-buttons-container > div{
+    position: relative;
+}
+
 .layer-button {
     background-color: #fff;
     border-radius: 7px;
@@ -585,6 +589,8 @@ body {
 .layer-button:hover{
     background-color: rgb(235, 230, 230);
 }
+
+
 
 .wind-button{
     background-image: url(../images/weather/wind.svg);
@@ -608,6 +614,45 @@ body {
     height: 35px !important;
     background-size: 100% 100%;
 }
+
+.layer-button-tooltip {
+    position: absolute;
+    left: -120px;
+    width: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    height: 100px;
+    top: -32px;
+}
+
+.layer-button-tooltip.hidden {
+    display: none;
+}
+
+.layer-button-tooltip .tooltip-container {
+    display: flex;
+    align-items: center;
+}
+
+.layer-button-tooltip .tooltip-text {
+    background-color: rgb(70, 70, 70);;
+    color: lightgray;
+    border-radius: 5px;
+    text-align: center;
+    font-size: 0.9rem;
+    padding: 5px;
+}
+
+.layer-button-tooltip .arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 7.5px 0 7.5px 10px;
+    border-color: transparent transparent transparent rgb(70, 70, 70);;
+}
+
+
 
 
 /* ** LEGEND ** */

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -374,9 +374,27 @@ co2Sub = function(str) {
                         </div>
                     </div>
                     <div class="layer-buttons-container">
-                        <button class="layer-button wind-button"/>
-                        <button class="layer-button solar-button"/>
+                        <div>
+                                <button class="layer-button wind-button"></button>
+                                <div id="wind-layer-button-tooltip"  class="layer-button-tooltip hidden">
+                                        <div class="tooltip-container">
+                                            <div class="tooltip-text"><%- __('tooltips.showWindLayer') %></div>
+                                            <div class="arrow"></div>
+                                        </div>
+                                </div>
+                        </div>
+                        <div>
+                                <button class="layer-button solar-button"></button>
+                                <div id="solar-layer-button-tooltip" class="layer-button-tooltip hidden">
+                                        <div class="tooltip-container">
+                                                <div class="tooltip-text"><%- __('tooltips.showSolarLayer') %></div>
+                                                <div class="arrow"></div>
+                                        </div>
+                                </div>
+                        </div>
+
                     </div>
+
 
 
                 </div>


### PR DESCRIPTION
Fixes #1300 

I opted to not use the existing tooltip component, at the other tooltips behave somewhat different (for instance they use block and not flex positioning, which is toggled in the show/hide functions). Also the existing tooltip component is a bit overkill for simple popovers such as these. We could easily extract them to a separate popover component at a later stage if we need to reuse the code. 

![image](https://user-images.githubusercontent.com/7040743/39263561-d927de58-48c2-11e8-943f-31492b47dd49.png)

![image](https://user-images.githubusercontent.com/7040743/39263578-e865e306-48c2-11e8-9dd6-9abbde404101.png)
