### PR TITLE
Update CA-BC capacities

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -591,12 +591,15 @@
       ]
     ],
     "capacity": {
-      "biomass": 356,
-      "gas": 514,
-      "hydro": 15004,
-      "oil": 46,
-      "wind": 673
+      "biomass": 838,
+      "gas": 507,
+      "hydro": 15898,
+      "solar": 1,
+      "wind": 704
     },
+    "contributors": [
+      "https://github.com/daveachuk"
+    ],
     "flag_file_name": "ca.png",
     "timezone": null
   },


### PR DESCRIPTION
Taken from the https://en.wikipedia.org/wiki/List_of_generating_stations_in_British_Columbia wiki page which I have just updated to the latest figures. These capacities exclude non-grid-connected capacity (remote or industrial microgrids). Now to get BC Hydro to release real-time data......