### PR TITLE
Moved tab bar to bottom. Changed font in zone list header. Mobile pad…

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1021,6 +1021,9 @@ function routeToPage(pageName, state) {
 
   d3.selectAll('#tab .list-item:not(.wind-toggle):not(.solar-toggle)').classed('active', false);
   d3.selectAll(`#tab .${pageName}-button`).classed('active', true);
+  if (pageName === 'country') {
+    d3.selectAll('#tab .highscore-button').classed('active', true);
+  }
 }
 function tryFetchHistory(state) {
   const { selectedZoneName } = state.application;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -972,7 +972,11 @@ div.highscore-button:hover {
 
 #tab {
     position: relative;
-    background-color: rgb(164, 164, 164);
+    background-color: rgb(70, 70, 70);
+    -webkit-box-shadow: 0px 0px 5px 1px rgba(0,0,0,0.3);
+    -moz-box-shadow: 0px 0px 5px 1px rgba(0,0,0,0.3);
+    box-shadow: 0px 0px 5px 1px rgba(0,0,0,0.3);
+    z-index: 1;
 }
 #tab-content {
     display: flex;
@@ -991,7 +995,6 @@ div.highscore-button:hover {
     padding-bottom: 10px;
     padding-top: 8px;
     font-family: "Catamaran", sans-serif;
-    color: #6b6b6b;
 }
 #tab.nomap #tab-content .list-item.map-button,
 {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1280,6 +1280,9 @@ sub {
     .left-panel {
         padding: 0 0 1rem 0;
     }
+    .left-panel-zone-details {
+        padding: 1rem;
+    }
     .left-panel, #map-container {
         width: 100%;
     }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -366,9 +366,7 @@ body {
 .mobile-info-tab p{
     margin: 0.6rem 0;
 }
-.mobile-info-tab p:first-child {
-    margin-top: 0;
-}
+
 .mobile-info-tab .info-text{
     padding-top: 1.5rem;
 }
@@ -851,6 +849,7 @@ div.highscore-button:hover {
 
 .zone-list-header .title {
     font-size: 1.3rem;
+    font-family: "Catamaran", sans-serif;
 }
 
 .zone-list-header .subtitle {
@@ -973,31 +972,35 @@ div.highscore-button:hover {
 
 #tab {
     position: relative;
+    background-color: rgb(164, 164, 164);
 }
 #tab-content {
     display: flex;
-    height: 40px;
+    height: 56px;
 }
 #tab #tab-content .list-item {
     display: flex;
 
     align-items: center;
-    justify-content: center;
+    justify-content: space-between;
     text-align: center;
+    flex-direction: column;
 
     width: 50%;
-
-    margin-bottom: 2px; /* For the border */
+    font-size: 12px;
+    padding-bottom: 10px;
+    padding-top: 8px;
+    font-family: "Catamaran", sans-serif;
+    color: #6b6b6b;
 }
 #tab.nomap #tab-content .list-item.map-button,
-#tab.nomap #tab-content .list-item.wind-toggle,
-#tab.nomap #tab-content .list-item.solar-toggle {
+{
     display: none;
 }
 #tab #tab-content .list-item.active {
     color: white;
-    border-bottom: 2px solid white;
-    margin-bottom: 0px;
+    font-size: 14px;
+    padding-top: 6px;
 }
 
 #tab #tab-content .list-item.active img,
@@ -1008,13 +1011,8 @@ div.highscore-button:hover {
     -o-filter: brightness(0%) invert(1);
     filter: brightness(0%) invert(1);
 }
-#tab #tab-content .list-item.active.wind-button,
-#tab #tab-content .list-item.active.solar-button {
-    border-bottom-color: lightgreen;
-}
+
 #tab #tab-content a {
-    padding-top: 0.2rem;
-    padding-bottom: 0.6rem;
     color: darkgrey;
 }
 #tab #tab-content a:hover {
@@ -1022,12 +1020,9 @@ div.highscore-button:hover {
     text-decoration: none;
 }
 #tab #tab-content i {
-    font-size: 1.5rem;
+    font-size: 24px;
 }
-#tab #tab-content img {
-    height: 1.2rem;
-    filter: unset;
-}
+
 
 sub {
     font-size: 60%;
@@ -1271,13 +1266,16 @@ sub {
 /* Small devices (phones, etc.) */
 @media (max-width: 767px) {
     #header {
-        min-height: 90px; /* required for old Safari */
+        min-height: 50px; /* required for old Safari */
     }
     #header-content .logo {
         margin-right: auto;
     }
     .small-screen-hidden {
         display: none;
+    }
+    .left-panel {
+        padding: 0 0 1rem 0;
     }
     .left-panel, #map-container {
         width: 100%;

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -121,26 +121,6 @@ co2Sub = function(str) {
                         <span class="current-datetime-from-now"></span>
                     </div>
                 </div>
-
-                <div id="tab">
-                    <div id="tab-content">
-                        <a class="list-item map-button">
-                            <div>
-                                <i class="material-icons" aria-hidden="true">map</i>
-                            </div>
-                        </a>
-                        <a class="list-item highscore-button">
-                            <div>
-                                <i class="material-icons" aria-hidden="true">view_list</i>
-                            </div>
-                        </a>
-                        <a class="list-item info-button">
-                            <div>
-                                <i class="material-icons" aria-hidden="true">info</i>
-                            </div>
-                        </a>
-                    </div>
-                </div>
             </div>
             <div id="inner">
 
@@ -466,6 +446,28 @@ co2Sub = function(str) {
                 </div>
 
                 <!-- end #inner -->
+            </div>
+            <div id="tab">
+                <div id="tab-content">
+                    <a class="list-item map-button">
+                       
+                            <i class="material-icons" aria-hidden="true">map</i>
+                            <span class="tab-label">Map</span>
+                        
+                    </a>
+                    <a class="list-item highscore-button">
+                    
+                            <i class="material-icons" aria-hidden="true">view_list</i>
+                            <span class="tab-label">Areas</span>
+                       
+                    </a>
+                    <a class="list-item info-button">
+                   
+                            <i class="material-icons" aria-hidden="true">info</i>
+                            <span class="tab-label">About</span>
+                        
+                    </a>
+                </div>
             </div>
         </div>
         <div id="country-tooltip" class="tooltip panel">


### PR DESCRIPTION
…ding fixes.

I've used google's design guidelines for the general layout of the tabs (including text labels): https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-behavior

I used the "catamaran" font, which is also used elsewhere in the app, for the tab labels. If we want to adhere 100% to googles guidelines, we could change it to Roboto, but then that font would need to be embedded as well. I think Catamaran looks good. 

I tried changing the zone list title text to Catamaran, and I think it looks much better. What do you guys think?

There is an issue with the tab bar being the same color as the zone list/info tab, and I've therefore included a drop shadow on the top of the tab bar (similar to what we are doing with the header). I haven't seen many apps with a drop shadow from the tab bar, but I think it looks ok. Let me know what you think. 

![image](https://user-images.githubusercontent.com/7040743/39515767-5719dc8e-4dfb-11e8-8889-fb1c8ebf21d8.png)

![image](https://user-images.githubusercontent.com/7040743/39515771-5c935398-4dfb-11e8-8a91-575516a075d6.png)


