### PR TITLE
switch CA-NB->CA-PE exchange to use PEI data

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -505,7 +505,7 @@
       46.7349
     ],
     "parsers": {
-      "exchange": "CA_NB.fetch_exchange"
+      "exchange": "CA_PE.fetch_exchange"
     },
     "rotation": 90
   },


### PR DESCRIPTION
Prince Edward Island has an area of 5660 km2 (roughly comparable to between Fyn and Sjælland), and has an installed wind capacity of around 200 MW. In practice this means that the production can be rather bumpy. Import from New Brunswick is used to provide extra energy when needed, but our data wasn't looking very intuitive:

![PEI origin of electricity chart](https://user-images.githubusercontent.com/47415/39662337-5077a520-5060-11e8-83a9-55caf599682e.png)
![PEI origin of electricity chart](https://user-images.githubusercontent.com/47415/39662338-52a928be-5060-11e8-86df-25ced45a3cae.png)
![PEI origin of electricity chart](https://user-images.githubusercontent.com/47415/39662422-751d23d6-5061-11e8-921b-869cff886c59.png)

We were using exchange data from the New Brunswick parser. PEI parser also can compute the exchange. Not to be outdone by Alex, I collected data computed by the two parsers, and compared them.

The PEI wind production and exchange data updates every 10 or 20 minutes. The New Brunswick exchange data updates once an hour. The PEI parser produces a much more intuitive-looking load-curve:

![PEI load curve with PEI and NB data](https://user-images.githubusercontent.com/47415/39662359-9a4b7b22-5060-11e8-8223-45b44f913548.png)

Looking at the exchange data we can see that while the data is ultimately the same, the NB data doesn't update as frequently and thus misses smaller bumps and time-shifts some bigger ones:

![PEI exchanges with PEI and NB data](https://user-images.githubusercontent.com/47415/39662370-b69d4df0-5060-11e8-8763-665eddacdc7a.png)

Source CSV: https://gist.github.com/jarek/d8886475b750af2626da0f8ad787616c

(I am also collecting data on New Brunswick's exchanges with other neighbours. Pull requests or writeups, if any arise, will follow.)