### PR TITLE
more validations for ENTSOE data

### DIFF
--- a/parsers/test/mocks/quality_check.py
+++ b/parsers/test/mocks/quality_check.py
@@ -215,3 +215,80 @@ p9 = {
       },
       'source': 'mysource.com'
       }
+
+p10 = {
+      'zoneKey': 'DE',
+      'production': {
+              'coal': 230.6,
+              'gas': 780.0,
+              'hydro': 340.2,
+              'nuclear': 2390.0,
+              'oil': 0.0,
+              'solar': 49.0,
+              'wind': 0.0,
+              'geothermal': 453.8,
+              'unknown': 10.0
+             },
+      'datetime': dt,
+      'source': 'mysource.com'
+      }
+
+p11 = {
+      'zoneKey': 'PL',
+      'production': {
+              'coal': 230.6,
+              'gas': 780.0
+             },
+      'datetime': dt,
+      'source': 'mysource.com'
+      }
+
+p12 = {
+      'zoneKey': 'SI',
+      'production': {
+              'biomass': 15,
+              'coal': 4000,
+              'gas': 14,
+              'geothermal': None,
+              'hydro': 856,
+              'nuclear': 692,
+              'oil': 0,
+              'solar': 94,
+              'unknown': None,
+              'wind': 1
+             },
+      'datetime': dt,
+      'source': 'mysource.com'
+      }
+
+p13 = {
+      'zoneKey': 'DK-DK1',
+      'production': {
+               'oil': 1,
+               'unknown': 79,
+               'coal': 534,
+               'wind': 2000,
+               'biomass': 583,
+               'gas': 215
+             },
+      'datetime': dt,
+      'source': 'entsoe.eu',
+}
+
+p14 = {
+      'zoneKey': 'FI',
+      'production': {
+               'nuclear': 2565,
+               'oil': 1,
+               'unknown': 79,
+               'coal': 534,
+               'hydro': 2176,
+               'wind': 42,
+               'biomass': 583,
+               'gas': 215,
+               'geothermal': None,
+               'solar': None
+             },
+      'datetime': dt,
+      'source': 'entsoe.eu',
+}

--- a/parsers/test/test_entsoe_quality.py
+++ b/parsers/test/test_entsoe_quality.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+"""Tests for validation in ENTSOE parser."""
+import logging
+import unittest
+from parsers.ENTSOE import validate_production
+from parsers.test.mocks.quality_check import *
+
+
+class ProductionTestCase(unittest.TestCase):
+    """Tests for ENTSOE's validate_production."""
+    test_logger = logging.getLogger()
+
+    def test_missing_required_biomass_in_DE(self):
+        validated = validate_production(p10, self.test_logger)
+        self.assertEqual(validated, None)
+
+    def test_production_too_low_in_PL(self):
+        validated = validate_production(p11, self.test_logger)
+        self.assertEqual(validated, None)
+
+    def test_production_too_high_in_SI(self):
+        validated = validate_production(p12, self.test_logger)
+        self.assertEqual(validated, None)
+
+    def test_missing_solar_in_DK1(self):
+        validated = validate_production(p13, self.test_logger)
+        self.assertEqual(validated, None)
+
+    def test_valid_production_in_FI(self):
+        validated = validate_production(p14, self.test_logger)
+        self.assertNotEqual(validated, None)
+        self.assertTrue('production' in validated)
+        self.assertTrue('hydro' in validated['production'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Whole categories of generation have been dropping off ENTSOE quite often. Quite often several types of generation will drop from Germany, it's particularly noticeable with biomass and hydro which are otherwise constant. Recently I saw Poland and Czechia with no coal. This enhances the tests a bit to catch more of these problems, and makes it a bit cleaner to add further validations.