### PR TITLE
PL translation for new strings

### DIFF
--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -9,7 +9,7 @@
     "mobile-info-tab": {
         "map-info-text": "Mapa pokazuje, ile CO2 jest aktualnie emitowanie przy produkcji twojej energii elektrycznej. Regiony są kolorowane według intensywności emisji CO2, wliczając potencjał tworzenia efektu cieplarnianego, jednostkowo według zużywanej tam energii elektrycznej. Zieleńsze odcienie oznaczają bardziej przyjazną dla klimatu energię elektryczną.",
         "electricity-origins-text": "Strzałki wykazują, gdzie i ile energii płynie pomiedzy regionami. Naciśnij region aby dowiedzieć się więcej o źródłach energii elektrycznej tam zużywanej.",
-        "wind-solar-text": "Produkcja wiatrowa i słoneczna zależy od pogody. Użyj przycisków \"wiatr\" i \"słońce\" aby zobaczyć aktualne prędkości wiatru i nasłonecznienie dookoła świata."
+        "wind-solar-text": "Produkcja wiatrowa i słoneczna zależą od pogody. Użyj przycisków \"wiatr\" i \"słońce\" aby zobaczyć aktualne prędkości wiatru i nasłonecznienie dookoła świata."
     },
     "onboarding-modal": {
         "view1": {
@@ -26,7 +26,7 @@
         },
         "view4": {
             "header": "Aktualne warunki wiatrowe i słoneczne",
-            "text": "Produkcja wiatrowa i słoneczna zależy od pogody. Użyj przycisków \"wiatr\" i \"słońce\" aby zobaczyć aktualne prędkości wiatru i nasłonecznienie dookoła świata."
+            "text": "Produkcja wiatrowa i słoneczna zależą od pogody. Użyj przycisków \"wiatr\" i \"słońce\" aby zobaczyć aktualne prędkości wiatru i nasłonecznienie dookoła świata."
         }
     },
     "country-panel": {
@@ -421,7 +421,7 @@
             "zoneName": "Grecja"
           },
           "GR-IS": {
-            "countryName": "Greece",
+            "countryName": "Grecja",
             "zoneName": "Wyspy Egejskie"
           },
           "GT": {

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -6,6 +6,29 @@
         "datasources": "źródła danych",
         "contribute": "Pomóż nam <a href=\"%s\" target=\"_blank\">dodając więcej regionów</a>"
     },
+    "mobile-info-tab": {
+        "map-info-text": "Mapa pokazuje, ile CO2 jest aktualnie emitowanie przy produkcji twojej energii elektrycznej. Regiony są kolorowane według intensywności emisji CO2, wliczając potencjał tworzenia efektu cieplarnianego, jednostkowo według zużywanej tam energii elektrycznej. Zieleńsze odcienie oznaczają bardziej przyjazną dla klimatu energię elektryczną.",
+        "electricity-origins-text": "Strzałki wykazują, gdzie i ile energii płynie pomiedzy regionami. Naciśnij region aby dowiedzieć się więcej o źródłach energii elektrycznej tam zużywanej.",
+        "wind-solar-text": "Produkcja wiatrowa i słoneczna zależy od pogody. Użyj przycisków \"wiatr\" i \"słońce\" aby zobaczyć aktualne prędkości wiatru i nasłonecznienie dookoła świata."
+    },
+    "onboarding-modal": {
+        "view1": {
+            "header": "Electricity Map",
+            "subtitle": "Obrazujemy wpływ produkcji energii elektrycznej na klimat"
+        },
+        "view2": {
+            "header": "Zobacz ile CO2 jest aktualnie emitowane przy produkcji twojej energii elektrycznej",
+            "text": "Regiony świata są kolorowane według intensywności emisji CO2, wliczając potencjał tworzenia efektu cieplarnianego, jednostkowo według zużywanej tam energii elektrycznej. Zieleńsze odcienie oznaczają bardziej przyjazną dla klimatu energię elektryczną."
+        },
+        "view3": {
+            "header": "Dowiedz się skąd pochodzi twój prąd",
+            "text": "Strzałki wykazują, gdzie i ile energii płynie pomiedzy regionami. Kliknij region aby dowiedzieć się więcej o źródłach energii elektrycznej tam zużywanej."
+        },
+        "view4": {
+            "header": "Aktualne warunki wiatrowe i słoneczne",
+            "text": "Produkcja wiatrowa i słoneczna zależy od pogody. Użyj przycisków \"wiatr\" i \"słońce\" aby zobaczyć aktualne prędkości wiatru i nasłonecznienie dookoła świata."
+        }
+    },
     "country-panel": {
         "source": "źródło",
         "carbonintensity": "Emisja CO2",
@@ -17,15 +40,21 @@
         "addeditsource": "<a href=\"%s\" target=\"_blank\">dodaj lub zmień źródło</a>",
         "helpfrom": "z wkładem"
     },
+    "left-panel": {
+        "zone-list-header-title": "Wpływ na klimat",
+        "zone-list-header-subtitle": "według emisji CO2 poprzez wytwarzanie energii elektrycznej (gCO2eq/kWh)",
+        "search": "Szukaj"
+    },
     "country-history": {
         "carbonintensity24h": "Emisja CO2 w ostatnich 24 godzinach",
+        "emissionsorigin24h": "Źródła emisji CO2 w ostatnich 24 godzinach",
         "electricityorigin24h": "Źródła energii elektrycznej w ostatnich 24 godzinach",
         "electricityprices24h": "Ceny energii elektrycznej w ostatnich 24 godzinach",
         "Getdata": "Sprawdź dane historyczne i API z prognozą"
     },
     "footer": {
         "likethisvisu": "Podoba Ci się nasza wizualizacja?",
-        "loveyourfeedback": "Podziel się z nami Twoją opinią",
+        "loveyourfeedback": "Podziel się z nami twoją opinią",
         "foundbugs": "Znalazłeś błąd lub masz własny pomysł? Daj nam znać",
         "here": "tutaj"
     },
@@ -39,18 +68,25 @@
         "carbonintensity": "Emisja CO2",
         "lowcarbon": "Niskoemisyjne źródła energii",
         "renewable": "Odnawialne źródła energii",
-        "crossborderexport": "Eksport transgraniczny",
+        "crossborderexport": "Eksport",
         "carbonintensityexport": "Emisja CO2 eksportu",
-
         "ofinstalled": "zainstalowanej mocy",
         "utilizing": "wykorzystując",
-        "withcarbonintensity": "z emisją CO2 wynoszącą"
+        "withcarbonintensity": "z emisją CO2 wynoszącą",
+        "showWindLayer": "Pokaż wiatr",
+        "hideWindLayer": "Schowaj wiatr",
+        "showSolarLayer": "Pokaż nasłonecznienie",
+        "hideSolarLayer": "Schowaj nasłonecznienie",
+        "noParserInfo": "Brak danych",
+        "temporaryDataOutage": "Tymczasowy brak danych"
     },
     "misc": {
         "maintitle": "Emisja CO2 konsumpcji energii elektrycznej w czasie rzeczywistym",
         "oops": "Ups! Mamy problemy z komunikacją z serwerem. Spróbujemy ponownie za kilka sekund.",
         "newversion": "Jest dostępna nowa wersja! <a onClick=\"location.reload(true);\">Załaduj ją</a>.",
-        "retrynow": "Spróbuj teraz"
+        "retrynow": "Spróbuj teraz",
+        "database-ad": "Szukasz danych historycznych? <a href=\"https://data.electricitymap.org?utm_source=electricitymap.org&utm_medium=referral\" target=\"_blank\">Sprawdź Electricity Map Database!</a>",
+        "api-ad": "Chcesz mieć aktualne dane w twoich aplikacjach lub urządzeniach? <a href=\"https://api.electricitymap.org?utm_source=electricitymap.org&utm_medium=referral\" target=\"_blank\">Spróbuj Electricity Map API!</a>"
     },
     "wind": "wiatrowa",
     "solar": "słoneczna",
@@ -147,19 +183,19 @@
           },
           "BR-CS": {
             "countryName": "Brazylia",
-            "zoneName": "centralna"
+            "zoneName": "Brazylia centralna"
           },
           "BR-N": {
             "countryName": "Brazylia",
-            "zoneName": "północna"
+            "zoneName": "Brazylia północna"
           },
           "BR-NE": {
             "countryName": "Brazylia",
-            "zoneName": "północno-wschodnia"
+            "zoneName": "Brazylia północno-wschodnia"
           },
           "BR-S": {
             "countryName": "Brazylia",
-            "zoneName": "południowa"
+            "zoneName": "Brazylia południowa"
           },
           "BY": {
             "zoneName": "Białoruś"
@@ -264,6 +300,14 @@
           "DK": {
             "zoneName": "Dania"
           },
+          "DK-DK1": {
+            "countryName": "Dania",
+            "zoneName": "Dania zachodnia"
+          },
+          "DK-DK2": {
+            "countryName": "Denmark",
+            "zoneName": "Dania wschodnia"
+          },
           "DK-BHM": {
             "countryName": "Dania",
             "zoneName": "Bornholm"
@@ -296,9 +340,25 @@
             "countryName": "Hiszpania",
             "zoneName": "Baleary"
           },
+          "ES-IB-ML": {
+            "countryName": "Hiszpania",
+            "zoneName": "Majorka"
+          },
+          "ES-IB-MN": {
+            "countryName": "Hiszpania",
+            "zoneName": "Minorka"
+          },
+          "ES-IB-IB": {
+            "countryName": "Hiszpania",
+            "zoneName": "Ibiza"
+          },
+          "ES-IB-FM": {
+            "countryName": "Hiszpania",
+            "zoneName": "Formentera"
+          },
           "ES-CN-FVLZ": {
             "countryName": "Hiszpania",
-            "zoneName": "Fuerteventura/Lanzarote"
+            "zoneName": "Fuerteventura i Lanzarote"
           },
           "ES-CN-GC": {
             "countryName": "Hiszpania",
@@ -359,6 +419,10 @@
           },
           "GR": {
             "zoneName": "Grecja"
+          },
+          "GR-IS": {
+            "countryName": "Greece",
+            "zoneName": "Wyspy Egejskie"
           },
           "GT": {
             "zoneName": "Gwatemala"
@@ -601,7 +665,7 @@
           },
           "MY-WM": {
             "countryName": "Malezja",
-            "zoneName": "półwysep"
+            "zoneName": "Malezja zachodnia"
           },
           "MZ": {
             "zoneName": "Mozambik"
@@ -614,6 +678,26 @@
           },
           "NO": {
             "zoneName": "Norwegia"
+          },
+          "NO-NO1": {
+            "countryName": "Norwegia",
+            "zoneName": "Norwegia południowo-wschodnia"
+          },
+          "NO-NO2": {
+            "countryName": "Norwegia",
+            "zoneName": "Norwegia południowo-zachodnia"
+          },
+          "NO-NO3": {
+            "countryName": "Norwegia",
+            "zoneName": "Norwegia środkowa"
+          },
+          "NO-NO4": {
+            "countryName": "Norwegia",
+            "zoneName": "Norwegia północna"
+          },
+          "NO-NO5": {
+            "countryName": "Norwegia",
+            "zoneName": "Norwegia zachodnia"
           },
           "NZ-NZN": {
             "countryName": "Nowa Zelandia",
@@ -741,9 +825,17 @@
             "countryName": "USA",
             "zoneName": "Alaska"
           },
+          "US-BPA": {
+            "countryName": "USA",
+            "zoneName": "sieć BPA"
+          },
           "US-CA": {
             "countryName": "USA",
             "zoneName": "Kalifornia"
+          },
+          "US-IPC": {
+            "countryName": "USA",
+            "zoneName": "sieć IPC"
           },
           "US-MISO": {
             "countryName": "USA",
@@ -760,6 +852,10 @@
           "US-PJM": {
             "countryName": "USA",
             "zoneName": "sieć PJM"
+          },
+          "US-SPP": {
+            "countryName": "USA",
+            "zoneName": "sieć SPP"
           },
           "US-HI": {
             "countryName": "USA",


### PR DESCRIPTION
Disclaimer! My Polish is a bit rusty for sentences, and I don't have much technical vocabulary. I spent a few hours checking translations on the internet, so I hope it's alright, but there might be errors. Is anyone else able to review? :poland: Czy ktoś mógłby spojrzeć i podzielić się swoim zdaniem?

A few questions:
- onboarding modal: should "The Electricity Map" to be translated? In Swedish it was.. but it's a product name? I just removed the "The" and kept "Electricity Map"
- In Database and API referral strings, should "Database" and "API" be translated? Swedish and Russian translated it, Italian did not (following #1184). I also went with "Electricity Map Database" interpreting the domain name, since the "our" doesn't translate cleanly to my ears...

Notes:
- "Map", "Areas", "About" at bottom of mobile view seems to not be localized at all
- `onboarding-modal view2 header` is the only onboarding header in English to have a full stop at the end. I didn't include it in Polish to keep consistent with the other onboarding headers
- I removed "cross-border" from "Cross-border export" since the word "transgraniczny" is a bit unelegant to me (mix of Latin prefix and Polish word); IMO it's not really confusing what kind of export it is; and "cross-border" is increasingly iffy with splitting more regions
- There was a left-over "Twoją" which I lowercased to "twoją". This is a semi-honorific rendering of the informal form of T-V distinctions, like capitalizing "Du" in German. Opinions on its necessity vary, but on the internet it seems a bit much to me.

If I may suggest - when you add a new string, if you have the time, also add it to another language you know, like French or Danish. That will make it much easier to triangulate the exact meaning :)

If any Polish people see this, kwestie, których nie jestem pewien:
- "region" czy może lepiej "obszar"?
- "eksport" czy może "wymiana"?
- "Twój" czy "twój"?
- "energia elektryczna", czy można czasem skrócić "prąd"?