### PR TITLE
Re-added exchange information for last data point for zones without p…

### DIFF
--- a/web/src/components/countrytable.js
+++ b/web/src/components/countrytable.js
@@ -466,6 +466,10 @@ CountryTable.prototype.data = function(arg) {
     this._data = arg;
 
     if (!this._data) { return this }
+
+    this.hasProductionData = this._data.production !== undefined && Object.keys(this._data.production).length > 0;
+    this.isMissingParser = this._data.hasParser === undefined || !this._data.hasParser;
+    
     if (this._exchangeKeys) {
         this._exchangeData = this._exchangeKeys
             .map(function(k) {
@@ -479,6 +483,10 @@ CountryTable.prototype.data = function(arg) {
             .sort(function(x, y) {
                 return d3.ascending(x.key, y.key);
             });
+    }
+    if (!this.hasProductionData){
+        // Remove exchange data values if no production is present, as table is greyed out
+        this._exchangeData.forEach(d => d.value = undefined);
     }
 
     // Construct a list having each production in the same order as this.MODES.
@@ -503,7 +511,6 @@ CountryTable.prototype.data = function(arg) {
         };
     });
 
-    this.isMissingParser = this._data.hasParser === undefined || !this._data.hasParser
     
     // update scales
     this.powerScale

--- a/web/src/reducers/dataReducer.js
+++ b/web/src/reducers/dataReducer.js
@@ -124,10 +124,6 @@ module.exports = (state = initialDataState, action) => {
         if (!zone.exchange || !Object.keys(zone.exchange).length) {
           console.warn(`${key} is missing exchanges`);
         } 
-        else if (!Object.keys(zone.production).length) {
-             // Exchange information is removed from observations without production data because it makes the exchange data percentages incorrect
-          zone.exchange = {};
-        }
 
       });
 
@@ -161,7 +157,7 @@ module.exports = (state = initialDataState, action) => {
         ret.hasParser = true;
         if (observation.exchange && Object.keys(observation.exchange).length
           && (!observation.production || !Object.keys(observation.production).length)) {
-              // Exchange information is removed from observations without production data because it makes the exchange data percentages incorrect
+              // Exchange information is not shown in history observations without production data, as the percentages are incorrect
           ret.exchange = {};
         }
 


### PR DESCRIPTION
…roduction (used in map exchanges). Instead removed this information directly in countrytable.js so it does not show in the consumption mix bar chart.

Fixes #1403 