### PR TITLE
Enable fetching of historical US exchange data

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -1376,6 +1376,16 @@
     },
     "rotation": 0
   },
+  "MX->US-CA": {
+    "lonlat": [
+      -116.027,
+      32.607
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": -10
+  },
   "NA->ZA":{
     "lonlat": [
       18.512,
@@ -1659,6 +1669,26 @@
     },
     "rotation": -135
   },
+  "US-BPA->US-IPC": {
+    "lonlat": [
+      -117.070,
+      47.369
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": 90
+  },
+  "US-ERCOT->US-SPP": {
+    "lonlat": [
+      -96.855,
+      33.761
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": 0
+  },
   "US-MISO->US-PJM": {
     "lonlat": [
       -84.803,
@@ -1668,6 +1698,16 @@
       "exchange": "US_PJM.fetch_exchange"
     },
     "rotation": 90
+  },
+  "US-MISO->US-SPP": {
+    "lonlat": [
+      -96.460,
+      44.371
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": -90
   },
   "US-NEISO->US-NY": {
     "lonlat": [

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -1,9 +1,10 @@
-import datetime
+#!/usr/bin/env python3
 
 import arrow
+from dateutil import parser
+from eiapy import Series
 import requests
 
-API_KEY = "b93a583eeed9d0ed324f3b21923af444"
 DAY_AHEAD = {
     'US-SPP': 'EBA.SWPP-ALL.DF.H',
     'US-MISO': 'EBA.MISO-ALL.DF.H',
@@ -11,45 +12,91 @@ DAY_AHEAD = {
     'US-NEISO': 'EBA.ISNE-ALL.DF.H',
     'US-NY': 'EBA.NYIS-ALL.DF.H',
     'US-PJM': 'EBA.PJM-ALL.DF.H',
+    'US-BPA': 'EBA.BPAT-ALL.DF.H',
+    'US-IPC': 'EBA.IPCO-ALL.DF.H'
 }
 
-
-def parse_response(url):
-    r = requests.get(url)
-    data = r.json()
-    data = data['series'][0]
-
-    values = []
-    # data['description'] states 'Timestamps follow the ISO8601 standard
-    # (https://en.wikipedia.org/wiki/ISO_8601). Hourly representations are
-    # provided in Universal Time.'
-    for dt, value in data['data']:
-        dt = arrow.get(datetime.datetime.strptime(dt, '%Y%m%dT%HZ'),
-                       'UTC').datetime
-        values.append((dt, value))
-
-    return values
-
-
-def keep_after(values, target_time):
-    min_time = arrow.get(target_time, tz='UTC').datetime
-    return [(dt, v) for (dt, v) in values if min_time <= dt]
+EXCHANGES = {
+    'MX->US-CA': 'EBA.CISO-CFE.ID.H',
+    'US-BPA->US-IPC': 'EBA.BPAT-IPCO.ID.H',
+    'US-ERCOT->US-SPP': 'EBA.ERCO-SWPP.ID.H',
+    'US-MISO->US-PJM': 'EBA.MISO-PJM.ID.H',
+    'US-MISO->US-SPP': 'EBA.MISO-SWPP.ID.H',
+    'US-NEISO->US-NY': 'EBA.ISNE-NYIS.ID.H',
+    'US-NY->US-PJM': 'EBA.NYIS-PJM.ID.H'
+}
 
 
 def fetch_consumption_forecast(zone_key, session=None, target_datetime=None,
                                logger=None):
+
     series_id = DAY_AHEAD[zone_key]
-    url = "http://api.eia.gov/series/?api_key={api_key}&series_id=" \
-          "{series_id}".format(api_key=API_KEY, series_id=series_id)
+    s = session or requests.Session()
+    forecast_series = Series(series_id=series_id, session=s)
 
-    values = parse_response(url)
+    if target_datetime:
+        raw_data = forecast_series.last_from(24, end=target_datetime)
+    else:
+        # Get the last 24 hours available.
+        raw_data = forecast_series.last(24)['series'][0]['data']
 
-    # we don't need to keep all values
-    values = keep_after(values, target_datetime)
+    # UTC timestamp with no offset returned.
 
     return [{
         'zoneKey': zone_key,
-        'datetime': dt,
-        'value': value,
+        'datetime': parser.parse(datapoint[0]),
+        'value': datapoint[1],
         'source': 'eia.org',
-    } for dt, value in values]
+    } for datapoint in raw_data]
+
+
+def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
+    """Requests the last known power exchange (in MW) between two zones
+    Arguments:
+    zone_key1           -- the first country code
+    zone_key2           -- the second country code; order of the two codes in params doesn't matter
+    session (optional)      -- request session passed in order to re-use an existing session
+    target_datetime (optional)      -- string in form YYYYMMDDTHHZ
+    Return:
+    A list of dictionaries in the form:
+    {
+      'sortedZoneKeys': 'DK->NO',
+      'datetime': '2017-01-01T00:00:00Z',
+      'netFlow': 0.0,
+      'source': 'mysource.com'
+    }
+    where net flow is from DK into NO
+    """
+
+    sortedcodes = '->'.join(sorted([zone_key1, zone_key2]))
+
+    series_id = EXCHANGES[sortedcodes]
+    s = session or requests.Session()
+    exchange_series = Series(series_id=series_id, session=s)
+
+    if target_datetime:
+        raw_data = exchange_series.last_from(24, end=target_datetime)
+    else:
+        # Get the last 24 hours available.
+        raw_data = exchange_series.last(24)['series'][0]['data']
+
+    data = []
+    for datapoint in raw_data:
+        if sortedcodes == 'MX->US-CA':
+            datapoint[1] = -1*datapoint[1]
+
+        exchange = {'sortedZoneKeys': sortedcodes,
+                    'datetime': parser.parse(datapoint[0]),
+                    'netFlow': datapoint[1],
+                    'source': 'mysource.com'}
+
+        data.append(exchange)
+
+    return data
+
+
+if __name__ == '__main__':
+    "Main method, never used by the Electricity Map backend, but handy for testing."
+
+    print(fetch_consumption_forecast('US-NY'))
+    print(fetch_exchange('MX', 'US-CA'))

--- a/parsers/requirements.txt
+++ b/parsers/requirements.txt
@@ -1,6 +1,7 @@
 arrow==0.10.0
 beautifulsoup4==4.5.3
 demjson==2.2.4
+eiapy==0.1.2
 html5lib==0.999999999
 lxml==3.7.3
 mock==2.0.0


### PR DESCRIPTION
This lets us get hourly exchange data for every US balancing authority going back to 2015.  It is delayed by ~1 day.  I have only included exchanges for which we have some data atm.  Two more consumption forecasts are also added.

The API key will need to be exported as a bash variable called 'EIA_KEY'.

ref #1257 