### PR TITLE
No onboarding when embedded

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -209,7 +209,8 @@ moment.locale(getState().application.locale.toLowerCase());
 // Analytics
 thirdPartyServices.trackWithCurrentApplicationState('Visit');
 
-if (!getState().application.onboardingSeen && !getState().isEmbedded) {
+// do not display onboarding when we've seen it or we're embedded
+if (!getState().application.onboardingSeen && !(window.top !== window.self)) {
   onboardingModal = new OnboardingModal('#main');
   thirdPartyServices.trackWithCurrentApplicationState('onboardingModalShown');
 }

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -14,7 +14,6 @@ const initialApplicationState = {
   colorBlindModeEnabled: Cookies.get('colorBlindModeEnabled') === 'true' || false,
   customDate: null,
   isCordova: window.isCordova,
-  isEmbedded: window.top !== window.self,
   isLeftPanelCollapsed: false,
   isMobile:
   (/android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i).test(navigator.userAgent),


### PR DESCRIPTION
fixes #1425 
Somehow the `getState().isEmbedded` was undefined when checking for it in main.js:213. Not sure why, but it's just as easy (though not as elegant) to directly check `window.top === window.self`

I've checked that
- I don't get onboarding when embedded and I have seen it
- I don't get onboarding when NOT embedded and I have seen it
- I don't get onboarding when embedded and I have NOT seen it
- I DO get onboarding when NOT embedded and I have NOT seen it