### PR TITLE
Keyboard navigation

### DIFF
--- a/web/src/components/searchbar.js
+++ b/web/src/components/searchbar.js
@@ -12,6 +12,7 @@ export default class SearchBar {
     this.searchHandler = config.searchHandler;
     this.enterKeypressHandler = config.enterKeypressHandler;
     this._setupEventHandlers();
+    this.inputNode = this.selector.node();
   }
 
   onSearch(searchHandler) {
@@ -22,10 +23,20 @@ export default class SearchBar {
     this.enterKeypressHandler = enterKeypressHandler;
   }
 
-  focus() {
-    const inputNode = this.selector.node();
-    inputNode.value = '';
-    inputNode.focus();
+  clearInputAndFocus() {
+    this.inputNode.value = '';
+    this.inputNode.focus();
+  }
+
+  focusWithInput(input) {
+    if (!this.hasFocus()) {
+      this.inputNode.value = this.inputNode.value + input;
+      this.inputNode.focus();
+    }
+  }
+
+  hasFocus() {
+    return document.activeElement === this.inputNode;
   }
 
   _setupEventHandlers() {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -915,6 +915,9 @@ div.highscore-button:hover {
     text-decoration: none;
     background: rgba(255,255,255,0.1)
 }
+.zone-list a.selected {
+    background-color: rgba(255,255,255,0.1);
+}
 
 .zone-list .ranking {
     width: 2rem;
@@ -950,6 +953,7 @@ div.highscore-button:hover {
     height: 17px;
     width: 17px;
 }
+
 
 
 

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -144,7 +144,6 @@ co2Sub = function(str) {
                         </div>
 
                         <div class="zone-list">
-                            <p></p>
                         </div>
 
                         <div class="info-text small-screen-hidden">


### PR DESCRIPTION
Fixes #1408 
Fixes #1130 

- Arrow key navigation nor works in zone list (up/down/enter keys). Highlighting is styled the same as mouse hover (hence no screenshot here)
- Pressing "/" focuses on search bar and clears its input
- Pressing any other character key auto-focuses on the search bar and preserves the input
- Pressing "/" in the zone details view transitions the user back to the zone list view, auto-focuses on the search bar and clears its input
- Pressing backspace in the zone details view transitions the user back to the zone list view, auto-focuses on the search bar and perserves the input
