### PR TITLE
remove IN-GJ parser

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1759,7 +1759,6 @@
     "flag_file_name": "in.png",
     "parsers": {
       "consumption": "IN_GJ.fetch_consumption",
-      "production": "IN_GJ.fetch_production"
     },
     "timezone": "Asia/Kolkata"
   },


### PR DESCRIPTION
We lost thermal data and the 24 hour history chart now implies they use 100% wind and solar:

![image](https://user-images.githubusercontent.com/47415/41739702-2baaec06-7596-11e8-84bc-2f6c2ff0a1e0.png)

Production was 10 to 14 GW before:

![image](https://user-images.githubusercontent.com/47415/41739712-33dc9744-7596-11e8-9df1-5d6c349f970c.png)
