### PR TITLE
Get IN-GJ working again

### DIFF
--- a/parsers/IN_GJ.py
+++ b/parsers/IN_GJ.py
@@ -15,7 +15,7 @@ station_map = {
      "coal": ["Ukai(1-5)+Ukai6",
              "Wanakbori",
              "Gandhinagar",
-             "Sikka(1-2)+Sikka(3-4)",
+             "Sikka(3-4)",
              "KLTPS(1-3)+KLTPS4",
              "SLPP(I+II)",
              "Akrimota",
@@ -28,9 +28,8 @@ station_map = {
               "Kadana(Hydro)",
               "SSP(RBPH)"],
     "gas": ["Utran(Gas)(II)",
-            "Dhuvaran(Gas)(I)+(II)",
-            "GIPCL(I)",
-            "GIPCL(II)",
+            "Dhuvaran(Gas)(I)+(II)+(III)",
+            "GIPCL(I)+(II)",
             "GSEG(I+II)",
             "GPPC",
             "CLPI",
@@ -80,7 +79,7 @@ def fetch_data(zone_key, session=None, logger=None):
 
     rows = web.get_response_soup(
         zone_key,
-        'https://www.sldcguj.com/RealTimeData/RealTimeDemand.php',
+        'http://www.sldcguj.com/RealTimeData/PrintPage.php?page=realtimedemand.php',
         session).find_all('tr')
 
     for row in rows:


### PR DESCRIPTION
Credit to @alixunderplatz for figuring out how to use the print page url to access the data.

```shell
(EM-env) chris@ThinkPad:~/electricitymap$ python -m parsers.IN_GJ
{'datetime': datetime.datetime(2018, 6, 23, 23, 10, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Kolkata')),
 'production': {'biomass': None,
                'coal': 7513.0,
                'gas': 1837.0,
                'geothermal': None,
                'hydro': 0,
                'nuclear': 0,
                'oil': None,
                'solar': 0,
                'unknown': 0,
                'wind': 1995.0},
 'source': 'sldcguj.com',
 'storage': {'hydro': None},
 'zoneKey': 'IN-GJ'}
{'consumption': 0,
 'datetime': datetime.datetime(2018, 6, 23, 23, 10, 50, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Kolkata')),
 'source': 'sldcguj.com',
 'zoneKey': 'IN-GJ'}
```