### PR TITLE
fixed country detail padding issue with longer text. changed Co2 <sub>

### DIFF
--- a/web/src/helpers/formatting.js
+++ b/web/src/helpers/formatting.js
@@ -4,7 +4,7 @@ var d3 = require('d3-format');
 var translation = require('./translation');
 
 var co2Sub = module.exports.co2Sub = function (str) {
-  return str.replace('CO2', 'CO<sub>2</sub>');
+  return str.replace('CO2', 'CO<span class="sub">2</span>');
 };
 module.exports.formatPower = function (d, numDigits) {
   // Assume MW input

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -119,7 +119,12 @@ line, path {
 }
 .country-panel-wrap {
     position: relative;
-    padding-top: 120px;
+    padding-top: 160px;
+}
+.country-panel-wrap .bysource {
+    font-size: smaller;
+    position: relative;
+    top: 0.8rem;
 }
 .country-history .loading {
     background-size: 1.7rem;
@@ -601,7 +606,8 @@ body {
 
 .country-col-headline {
     font-size: 0.85em;
-    padding: 0.5em 0 0 0;
+    padding: 0.75em 0 0 0;
+    line-height: 1.25em;
     margin-top: auto;
     margin-bottom: auto;
 }
@@ -616,7 +622,7 @@ body {
 .country-col .country-col-subtext {
     margin-top: 0.375rem;
     font-size: 0.5rem;
-    line-height: 0.5rem;
+    line-height: 0rem;
 }
 .country-col .country-col-box {
     margin: 0 auto;
@@ -653,9 +659,7 @@ body {
     margin: 1.2rem 0 0 0;
     font-size: 1.1em;
 }
-.country-show-emissions-wrap .bysource {
-    font-size: smaller;
-}
+
 .country-show-emissions-wrap .menu {
     font-size: smaller;
     text-align: center;
@@ -1201,7 +1205,9 @@ div.highscore-button:hover {
 }
 
 
-sub {
+.sub {
+    position: relative;
+    top: 0.8ex;
     font-size: 60%;
 }
 
@@ -1763,6 +1769,7 @@ sub {
         position: relative;
         padding-top: 0;
     }
+
     .zone-time-slider{
         padding-top: 4px;
     }

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -1,6 +1,6 @@
 <%
 co2Sub = function(str) {
-    return (str || '').replace("CO2", "CO<sub>2</sub>");
+    return (str || '').replace("CO2", "CO<span class='sub'>2</span>");
 }
 %>
 <!DOCTYPE html>
@@ -284,7 +284,7 @@ co2Sub = function(str) {
                                             <div><span class="country-emission-intensity"></span>g</div>
                                         </div>
                                         <div class="country-col-headline"><%- co2Sub(__('country-panel.carbonintensity')) %></div>
-                                        <div class="country-col-subtext">(gCO<sub>2</sub>eq/kWh)</div>
+                                        <div class="country-col-subtext">(gCO<span class="sub">2</span>eq/kWh)</div>
                                     </div>
                                     <div class="country-col country-lowcarbon-wrap">
                                         <div id="country-lowcarbon-gauge" class="country-gauge-wrap"></div>
@@ -296,18 +296,18 @@ co2Sub = function(str) {
                                         <div class="country-col-headline"><%- __('country-panel.renewable') %></div>
                                     </div>
                                 </div>
-                            </div>
-
-                            <div class="country-panel-wrap">
                                 <div class="country-show-emissions-wrap">
                                     <div class="menu">
                                         <a id="production" href="javascript:toggleSource(false)"><%- __('country-panel.electricity') %></a>
                                         |
                                         <a id="emissions" href="javascript:toggleSource(true)"><%- co2Sub(__('country-panel.emissions')) %></a>
                                     </div>
-                                    <div class="bysource">
-                                        <%- __('country-panel.bysource') %>
-                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="country-panel-wrap">
+                                <div class="bysource">
+                                    <%- __('country-panel.bysource') %>
                                 </div>
                                 <div class="country-table-container"></div>
                             </div>
@@ -434,7 +434,7 @@ co2Sub = function(str) {
                                 <svg class="solar-potential-bar potential-bar colorbar"></svg>
                         </div>
                         <div class="co2-legend floating-legend">
-                                <div class="legend-header"><%- co2Sub(__('legends.carbonintensity'))%> <small>(gCO<sub>2</sub>eq/kWh)</small></div>
+                                <div class="legend-header"><%- co2Sub(__('legends.carbonintensity'))%> <small>(gCO<span class="sub">2</span>eq/kWh)</small></div>
                                 <svg class="co2-colorbar colorbar potential-bar"></svg>
                         </div>
                     </div>
@@ -544,7 +544,7 @@ co2Sub = function(str) {
             <img class="from flag"></img> <span id="from"></span> → <img class="to flag"></img> <span id="to"></span>: <span id="flow" style="font-weight: bold"></span> MW<br />
             <br />
             <%- co2Sub(__('tooltips.carbonintensityexport')) %>:<br />
-            <div class="emission-rect"></div> <span class="country-emission-intensity emission-intensity"></span> gCO<sub>2</sub>eq/kWh
+            <div class="emission-rect"></div> <span class="country-emission-intensity emission-intensity"></span> gCO<span class="sub">2</span>eq/kWh
         </div>
         <div id="price-tooltip" class="tooltip panel">
             <span class="value"></span> <span class="currency"></span>/MWh
@@ -558,7 +558,7 @@ co2Sub = function(str) {
                 <small>(<span id="capacity-factor-detail"></span>)</small><br />
                 <br />
                 <%- co2Sub(__('tooltips.withcarbonintensity')) %><br />
-                <div class="emission-rect"></div> <span class="emission-intensity"></span> gCO<sub>2</sub>eq/kWh <small>(<%- __('country-panel.source') %>: <span class="emission-source"></span>)</small>
+                <div class="emission-rect"></div> <span class="emission-intensity"></span> gCO<span class="sub">2</span>eq/kWh <small>(<%- __('country-panel.source') %>: <span class="emission-source"></span>)</small>
             </span>
         </div>
         <div id="countrypanel-exchange-tooltip" class="tooltip panel">
@@ -570,7 +570,7 @@ co2Sub = function(str) {
                 <small>(<span id="capacity-factor-detail"></span>)</small><br />
                 <br />
                 <%- co2Sub(__('tooltips.withcarbonintensity')) %><br />
-                <img class="country-exchange-source-flag flag"></img> <span class="country-exchange-source-name"></span>: <div class="emission-rect"></div> <span class="emission-intensity"></span> gCO<sub>2</sub>eq/kWh<br />
+                <img class="country-exchange-source-flag flag"></img> <span class="country-exchange-source-name"></span>: <div class="emission-rect"></div> <span class="emission-intensity"></span> gCO<span class="sub">2</span>eq/kWh<br />
             </span>
         </div>
     </body>


### PR DESCRIPTION
fixes #1491 

Changes I made:

- Added the "Electricity | Carbon emissions" menu into the absolute header, so that it's always visible.
- Reformatted the co2-gage headers (line-height etc) so that 3 lines wouldn't take up much more space
- Increased padding on the content to account for the menu and 3 lines height.
- Changed the Co2 sub implementation <sub> increases the box-height of the text, which makes it hard to make consistent height predictions. replacing it with <span class="sub"> fixes that.
- I opted for this approach keeping the absolute header because i still think it's good to always see it. however if it causes more problems in the future we have two options: (1) remove absolute positioning, (2) javascript read header height and set padding (not recommended)

result:
![screen shot 2018-07-03 at 12 43 03](https://user-images.githubusercontent.com/20746301/42215428-b03987da-7ebe-11e8-825b-077e00986191.JPG)

