### PR TITLE
Fix IQ parser running on import

### DIFF
--- a/parsers/IQ.py
+++ b/parsers/IQ.py
@@ -107,7 +107,8 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
     return exchange
 
 
-print(fetch_production())
-print(fetch_consumption())
-print(fetch_exchange('IQ', 'IR'))
-print(fetch_exchange('IQ', 'IQ-KUR'))
+if __name__ == '__main__':
+    print(fetch_production())
+    print(fetch_consumption())
+    print(fetch_exchange('IQ', 'IR'))
+    print(fetch_exchange('IQ', 'IQ-KUR'))


### PR DESCRIPTION
Super small PR, more an FYI for you @alixunderplatz and @systemcatch 

When importing the IQ parser, the 

```python
print(fetch_production())
print(fetch_consumption())
print(fetch_exchange('IQ', 'IR'))
print(fetch_exchange('IQ', 'IQ-KUR'))
```

at the end of the file is run, so I've wrapped it after a `if __name__ == '__main__':` line. That way, it's only run when launching the file `python IQ.py`, not when importing the parser from another python file.

