### PR TITLE
remove Albania override

### DIFF
--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -101,13 +101,6 @@ var countryCo2eqFootprint = {
 };
 
 var defaultExportCo2eqFootprint = {
-  'AL': {
-        carbonIntensity: 24,
-        renewableRatio: 1.00,
-        fossilFuelRatio: 0.00,
-        source: 'IEA yearly data for 2015',
-        url: 'https://www.iea.org/statistics/statisticssearch/report/?country=ALBANIA&product=electricityandheat&year=2015'
-    },
     'AZ': {
         carbonIntensity: 470,
         renewableRatio: 0.07,


### PR DESCRIPTION
per @alixunderplatz https://tmrow-team.slack.com/archives/C2DQPTHA6/p1530429840000010:

"The hardcoded carbon intensity for Albania (24 g/kWh) should be removed for now. 
There are regular power flows from Montenegro and Greece during the day with high emission intensities, and a high share of these imports is going to Serbia/Kosovo."